### PR TITLE
HOPSWORKS-676 Make SparkUI logs intuitive

### DIFF
--- a/hops/allreduce.py
+++ b/hops/allreduce.py
@@ -18,7 +18,7 @@ from hops import util
 
 run_id = 0
 
-def launch(sc, notebook, local_logdir=False):
+def launch(sc, notebook, local_logdir=False, name="no-name"):
     """ Run notebook pointed to in HopsFS as a python file in mpirun
     Args:
       :spark_session: SparkSession object
@@ -34,6 +34,9 @@ def launch(sc, notebook, local_logdir=False):
 
     #Each TF task should be run on 1 executor
     nodeRDD = sc.parallelize(range(1), 1)
+
+    #Make SparkUI intuitive by grouping jobs
+    sc.setJobGroup("Horovod training", "{} | Horovod training".format(name))
 
     #Force execution on executor, since GPU is located on executor
     nodeRDD.foreachPartition(prepare_func(app_id, run_id, notebook, local_logdir))

--- a/hops/differential_evolution.py
+++ b/hops/differential_evolution.py
@@ -505,7 +505,7 @@ def _evolutionary_launch(spark_session, map_fun, args_dict=None):
     global generation_id
     global run_id
     #Make SparkUI intuitive by grouping jobs
-    sc.setJobGroup("Evo Search Generation: {}".format(generation_id), "Tests different hyperparameters in evolutionary search, generation:".format(generation_id))
+    sc.setJobGroup("Evo Search Generation: {}".format(generation_id), "Tests different hyperparameters in evolutionary search, generation: {}".format(generation_id))
     nodeRDD.foreachPartition(_prepare_func(app_id, generation_id, map_fun, args_dict, run_id))
 
     generation_id += 1

--- a/hops/differential_evolution.py
+++ b/hops/differential_evolution.py
@@ -504,6 +504,8 @@ def _evolutionary_launch(spark_session, map_fun, args_dict=None):
     #Force execution on executor, since GPU is located on executor
     global generation_id
     global run_id
+    #Make SparkUI intuitive by grouping jobs
+    sc.setJobGroup("Evo Search Generation: {}".format(generation_id), "Tests different hyperparameters in evolutionary search, generation:".format(generation_id))
     nodeRDD.foreachPartition(_prepare_func(app_id, generation_id, map_fun, args_dict, run_id))
 
     generation_id += 1

--- a/hops/differential_evolution.py
+++ b/hops/differential_evolution.py
@@ -504,6 +504,7 @@ def _evolutionary_launch(spark_session, map_fun, args_dict=None):
     #Force execution on executor, since GPU is located on executor
     global generation_id
     global run_id
+
     #Make SparkUI intuitive by grouping jobs
     sc.setJobGroup("Evo Search Generation: {}".format(generation_id), "Tests different hyperparameters in evolutionary search, generation: {}".format(generation_id))
     nodeRDD.foreachPartition(_prepare_func(app_id, generation_id, map_fun, args_dict, run_id))

--- a/hops/dist_allreduce.py
+++ b/hops/dist_allreduce.py
@@ -21,7 +21,7 @@ import coordination_server
 
 run_id = 0
 
-def launch(spark_session, notebook):
+def launch(spark_session, notebook, name="no-name"):
     """ Run notebook pointed to in HopsFS as a python file in mpirun
     Args:
       :spark_session: SparkSession object
@@ -42,6 +42,9 @@ def launch(spark_session, notebook):
 
     server = coordination_server.Server(conf_num)
     server_addr = server.start()
+
+    #Make SparkUI intuitive by grouping jobs
+    sc.setJobGroup("Horovod training", "{} | Horovod training".format(name))
 
     #Force execution on executor, since GPU is located on executor
     nodeRDD.foreachPartition(prepare_func(app_id, run_id, notebook, server_addr))

--- a/hops/dist_allreduce.py
+++ b/hops/dist_allreduce.py
@@ -21,7 +21,7 @@ import coordination_server
 
 run_id = 0
 
-def launch(spark_session, notebook, name="no-name"):
+def launch(spark_session, notebook):
     """ Run notebook pointed to in HopsFS as a python file in mpirun
     Args:
       :spark_session: SparkSession object
@@ -42,9 +42,6 @@ def launch(spark_session, notebook, name="no-name"):
 
     server = coordination_server.Server(conf_num)
     server_addr = server.start()
-
-    #Make SparkUI intuitive by grouping jobs
-    sc.setJobGroup("Horovod training", "{} | Horovod training".format(name))
 
     #Force execution on executor, since GPU is located on executor
     nodeRDD.foreachPartition(prepare_func(app_id, run_id, notebook, server_addr))

--- a/hops/experiment.py
+++ b/hops/experiment.py
@@ -182,7 +182,6 @@ def evolutionary_search(spark, objective_function, search_dict, direction = 'max
       :map_fun: The TensorFlow function to run
       :search_dict: (optional) A dictionary containing differential evolutionary boundaries
     """
-    spark.sparkContext.setJobGroup("{}".format(name), "evolutionary search {}".format(name))
     global running
     if running:
         raise RuntimeError("An experiment is currently running. Please call experiment.end() to stop it.")

--- a/hops/experiment.py
+++ b/hops/experiment.py
@@ -204,7 +204,7 @@ def evolutionary_search(spark, objective_function, search_dict, direction = 'max
 
         util.put_elastic(hopshdfs.project_name(), app_id, elastic_id, experiment_json)
 
-        tensorboard_logdir, best_param, best_metric = diff_evo._search(spark, objective_function, search_dict, direction=direction, generations=generations, popsize=population, mutation=mutation, crossover=crossover, cleanup_generations=cleanup_generations, local_logdir=local_logdir)
+        tensorboard_logdir, best_param, best_metric = diff_evo._search(spark, objective_function, search_dict, direction=direction, generations=generations, popsize=population, mutation=mutation, crossover=crossover, cleanup_generations=cleanup_generations, local_logdir=local_logdir, name=name)
 
         experiment_json = util.finalize_experiment(experiment_json, best_param, best_metric)
 
@@ -258,7 +258,7 @@ def grid_search(spark, map_fun, args_dict, direction='max', name='no-name', loca
 
         grid_params = util.grid_params(args_dict)
 
-        tensorboard_logdir, param, metric = gs._grid_launch(sc, map_fun, grid_params, direction=direction, local_logdir=local_logdir)
+        tensorboard_logdir, param, metric = gs._grid_launch(sc, map_fun, grid_params, direction=direction, local_logdir=local_logdir, name=name)
 
         experiment_json = util.finalize_experiment(experiment_json, param, metric)
 

--- a/hops/experiment.py
+++ b/hops/experiment.py
@@ -168,6 +168,8 @@ def launch(spark, map_fun, args_dict=None, name='no-name', local_logdir=False, v
         exception_handler()
         raise
     finally:
+        #cleanup spark jobs
+        sc.setJobGroup("", "")
         elastic_id +=1
         running = False
 
@@ -216,11 +218,11 @@ def evolutionary_search(spark, objective_function, search_dict, direction = 'max
         exception_handler()
         raise
     finally:
+        #cleanup spark jobs
+        sc.setJobGroup("", "")
         elastic_id +=1
         running = False
 
-    #cleanup spark jobs
-    sc.setJobGroup("", "")
     return tensorboard_logdir, best_param_dict
 
 def grid_search(spark, map_fun, args_dict, direction='max', name='no-name', local_logdir=False, versioned_resources=None, description=None):
@@ -267,11 +269,11 @@ def grid_search(spark, map_fun, args_dict, direction='max', name='no-name', loca
         exception_handler()
         raise
     finally:
+        #cleanup spark jobs
+        sc.setJobGroup("", "")
         elastic_id +=1
         running = False
 
-    #cleanup spark jobs
-    sc.setJobGroup("", "")
     return tensorboard_logdir
 
 def horovod(spark, notebook, name='no-name', local_logdir=False, versioned_resources=None, description=None):
@@ -316,11 +318,10 @@ def horovod(spark, notebook, name='no-name', local_logdir=False, versioned_resou
         exception_handler()
         raise
     finally:
+        #cleanup spark jobs
+        sc.setJobGroup("", "")
         elastic_id +=1
         running = False
-
-    #cleanup spark jobs
-    sc.setJobGroup("", "")
 
     return tensorboard_logdir
 

--- a/hops/experiment.py
+++ b/hops/experiment.py
@@ -219,6 +219,8 @@ def evolutionary_search(spark, objective_function, search_dict, direction = 'max
         elastic_id +=1
         running = False
 
+    #cleanup spark jobs
+    sc.setJobGroup("", "")
     return tensorboard_logdir, best_param_dict
 
 def grid_search(spark, map_fun, args_dict, direction='max', name='no-name', local_logdir=False, versioned_resources=None, description=None):
@@ -268,6 +270,8 @@ def grid_search(spark, map_fun, args_dict, direction='max', name='no-name', loca
         elastic_id +=1
         running = False
 
+    #cleanup spark jobs
+    sc.setJobGroup("", "")
     return tensorboard_logdir
 
 def horovod(spark, notebook, name='no-name', local_logdir=False, versioned_resources=None, description=None):

--- a/hops/experiment.py
+++ b/hops/experiment.py
@@ -182,6 +182,7 @@ def evolutionary_search(spark, objective_function, search_dict, direction = 'max
       :map_fun: The TensorFlow function to run
       :search_dict: (optional) A dictionary containing differential evolutionary boundaries
     """
+    spark.sparkContext.setJobGroup("{}".format(name), "evolutionary search {}".format(name))
     global running
     if running:
         raise RuntimeError("An experiment is currently running. Please call experiment.end() to stop it.")

--- a/hops/experiment.py
+++ b/hops/experiment.py
@@ -306,7 +306,7 @@ def horovod(spark, notebook, name='no-name', local_logdir=False, versioned_resou
 
         util.put_elastic(hopshdfs.project_name(), app_id, elastic_id, experiment_json)
 
-        tensorboard_logdir = allreduce.launch(sc, notebook, local_logdir=local_logdir)
+        tensorboard_logdir = allreduce.launch(sc, notebook, local_logdir=local_logdir, name=name)
 
         experiment_json = util.finalize_experiment(experiment_json, None, None)
 
@@ -318,6 +318,9 @@ def horovod(spark, notebook, name='no-name', local_logdir=False, versioned_resou
     finally:
         elastic_id +=1
         running = False
+
+    #cleanup spark jobs
+    sc.setJobGroup("", "")
 
     return tensorboard_logdir
 

--- a/hops/grid_search.py
+++ b/hops/grid_search.py
@@ -17,7 +17,7 @@ import datetime
 
 run_id = 0
 
-def _grid_launch(sc, map_fun, args_dict, direction='max', local_logdir=False):
+def _grid_launch(sc, map_fun, args_dict, direction='max', local_logdir=False, name="no-name"):
     """ Run the wrapper function with each hyperparameter combination as specified by the dictionary
 
     Args:
@@ -43,7 +43,7 @@ def _grid_launch(sc, map_fun, args_dict, direction='max', local_logdir=False):
     nodeRDD = sc.parallelize(range(num_executions), num_executions)
 
     #Make SparkUI intuitive by grouping jobs
-    sc.setJobGroup("Grid search", "Grid search through supplied hyperparameters")
+    sc.setJobGroup("Grid search", "{} | Grid search through supplied hyperparameters".format(name))
 
     #Force execution on executor, since GPU is located on executor
     job_start = datetime.datetime.now()

--- a/hops/grid_search.py
+++ b/hops/grid_search.py
@@ -42,6 +42,9 @@ def _grid_launch(sc, map_fun, args_dict, direction='max', local_logdir=False):
     #Each TF task should be run on 1 executor
     nodeRDD = sc.parallelize(range(num_executions), num_executions)
 
+    #Make SparkUI intuitive by grouping jobs
+    sc.setJobGroup("Grid search", "Grid search through supplied hyperparameters")
+
     #Force execution on executor, since GPU is located on executor
     job_start = datetime.datetime.now()
     nodeRDD.foreachPartition(_prepare_func(app_id, run_id, map_fun, args_dict, local_logdir))

--- a/hops/launcher.py
+++ b/hops/launcher.py
@@ -13,7 +13,7 @@ import os
 run_id = 0
 
 
-def launch(sc, map_fun, args_dict=None, local_logdir=False):
+def launch(sc, map_fun, args_dict=None, local_logdir=False, name="no-name"):
 
     global run_id
 
@@ -30,6 +30,7 @@ def launch(sc, map_fun, args_dict=None, local_logdir=False):
                 raise ValueError('Length of each function argument list must be equal')
             num_executions = len(arg_lists[i])
 
+    sc.setJobGroup("Launcher", "{} | Running experiment".format(name))
     #Each TF task should be run on 1 executor
     nodeRDD = sc.parallelize(range(num_executions), num_executions)
 

--- a/hops/tensorflowonspark/TFCluster.py
+++ b/hops/tensorflowonspark/TFCluster.py
@@ -207,6 +207,7 @@ class TFCluster(object):
       q.put(None)
       q.join()
 
+
     # wait for all jobs to finish
     done = False
     while not done:
@@ -215,6 +216,9 @@ class TFCluster(object):
       jobs = st.getActiveJobsIds()
       if len(jobs) == 0:
         break
+
+        #cleanup spark jobs
+    self.sc.setJobGroup("", "")
 
     def tensorboard_url(self):
       """
@@ -321,8 +325,10 @@ def run(sc, map_fun, tf_args, num_executors, num_ps, tensorboard=False, input_mo
 
   # start TF on a background thread (on Spark driver) to allow for feeding job
 
-  def _start(status):
+  def _start(status, name=name):
     try:
+      #Make SparkUI intuitive by grouping jobs
+      sc.setJobGroup("TFOnSpark training", "{} | TFOnSpark distributed training".format(name))
       nodeRDD.foreachPartition(TFSparkNode.run(map_fun,
                                              tf_args,
                                              cluster_meta,


### PR DESCRIPTION
This PR groups spark tasks into JobGroups with intuitive names that shows up in the SparkUI. 

The JobGroups have been added and tested for to:

- evolutionary search
- grid search
- horovod
- TFOS

See pictures below for the test results.

![evo1](https://user-images.githubusercontent.com/8254791/45828355-a15df200-bcf8-11e8-8897-95d864f7d556.png)
![grid_search](https://user-images.githubusercontent.com/8254791/45828356-a15df200-bcf8-11e8-8b3e-aa9446d0c2ea.png)
![horovod](https://user-images.githubusercontent.com/8254791/45828357-a15df200-bcf8-11e8-92b8-512524a54c47.png)
![tfos](https://user-images.githubusercontent.com/8254791/45828358-a15df200-bcf8-11e8-8a38-2edcc22bd053.png)
