### PR TITLE
[HOPSWORKS-1057] Add additional API calls to hdfs module and bugfixes

### DIFF
--- a/it_tests/integration_tests.ipynb
+++ b/it_tests/integration_tests.ipynb
@@ -18,37 +18,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Starting Spark application\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<tr><th>ID</th><th>YARN Application ID</th><th>Kind</th><th>State</th><th>Spark UI</th><th>Driver log</th><th>Current session?</th></tr><tr><td>0</td><td>application_1554468059973_0008</td><td>pyspark</td><td>idle</td><td><a target=\"_blank\" href=\"http://hopsworks0.logicalclocks.com:8088/proxy/application_1554468059973_0008/\">Link</a></td><td><a target=\"_blank\" href=\"http://hopsworks0.logicalclocks.com:8042/node/containerlogs/container_e01_1554468059973_0008_01_000001/project_d10f980f39ae0afb__2da7f798\">Link</a></td><td>✔</td></tr></table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SparkSession available as 'spark'.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from hops import experiment, hdfs, tensorboard, devices, kafka, featurestore, tls, util\n",
     "import stat\n",
@@ -87,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,45 +108,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finished Experiment \n",
-      "\n",
-      "u'hdfs://10.0.2.15:8020/Projects/project_bde67d4d2ef6dcfc/Experiments/application_1552647327939_0024/launcher/run.3'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "experiment.launch(wrapper, local_logdir=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finished Experiment \n",
-      "\n",
-      "u'hdfs://10.0.2.15:8020/Projects/project_bde67d4d2ef6dcfc/Experiments/application_1552647327939_0024/launcher/run.4'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "experiment.launch(wrapper, description='very interesting description', local_logdir=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,38 +142,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finished Experiment \n",
-      "\n",
-      "u'hdfs://10.0.2.15:8020/Projects/project_bde67d4d2ef6dcfc/Experiments/application_1552647327939_0024/launcher/run.7'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "experiment.launch(parameter_wrapper, {'a': [1,2], 'b': [-1,1]}, local_logdir=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finished Experiment \n",
-      "\n",
-      "u'hdfs://10.0.2.15:8020/Projects/project_bde67d4d2ef6dcfc/Experiments/application_1552647327939_0024/launcher/run.8'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "experiment.launch(parameter_wrapper, {'a': [1,2], 'b': [-1,1]}, description='very interesting description', local_logdir=False)"
    ]
@@ -235,139 +167,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "------ Grid Search results ------ direction(min) \n",
-      "BEST combination a=1.b=-1 -- metric 0.0\n",
-      "WORST combination a=2.b=1 -- metric 3.0\n",
-      "AVERAGE metric -- 1.5\n",
-      "Total job time 1 seconds\n",
-      "\n",
-      "Finished Experiment \n",
-      "\n",
-      "u'hdfs://10.0.2.15:8020/Projects/project_bde67d4d2ef6dcfc/Experiments/application_1552647327939_0024/grid_search/run.1'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "experiment.grid_search(parameter_wrapper, {'a': [1,2], 'b': [-1,1]}, direction='min', name='test')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "------ Grid Search results ------ direction(max) \n",
-      "BEST combination a=2.b=1 -- metric 3.0\n",
-      "WORST combination a=1.b=-1 -- metric 0.0\n",
-      "AVERAGE metric -- 1.5\n",
-      "Total job time 1 seconds\n",
-      "\n",
-      "Finished Experiment \n",
-      "\n",
-      "u'hdfs://10.0.2.15:8020/Projects/project_bde67d4d2ef6dcfc/Experiments/application_1552647327939_0024/grid_search/run.2'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "experiment.grid_search(parameter_wrapper, {'a': [1,2], 'b': [-1,1]}, direction='max', name='test', local_logdir=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "------ Random Search results ------ direction(max) \n",
-      "BEST combination a=2.b=1 -- metric 3.0\n",
-      "WORST combination a=1.b=0 -- metric 1.0\n",
-      "AVERAGE metric -- 1.8\n",
-      "Total job time 2 seconds\n",
-      "\n",
-      "Finished Experiment \n",
-      "\n",
-      "u'hdfs://10.0.2.15:8020/Projects/project_bde67d4d2ef6dcfc/Experiments/application_1552647327939_0024/random_search/run.1'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "experiment.random_search(parameter_wrapper, {'a': [1,2], 'b': [-1,1]}, direction='max', name='test')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "------ Random Search results ------ direction(min) \n",
-      "BEST combination a=2.b=-1 -- metric 1.0\n",
-      "WORST combination a=2.b=0 -- metric 2.0\n",
-      "AVERAGE metric -- 1.5\n",
-      "Total job time 7 seconds\n",
-      "\n",
-      "Finished Experiment \n",
-      "\n",
-      "u'hdfs://10.0.2.15:8020/Projects/project_bde67d4d2ef6dcfc/Experiments/application_1552647327939_0024/random_search/run.2'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "experiment.random_search(parameter_wrapper, {'a': [1,2], 'b': [-1,1]}, direction='min', samples=3, name='test', local_logdir=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generation 0 || average metric: 1.66666666667, best metric: 3.0, best parameter combination: ['a=2', 'b=1']\n",
-      "\n",
-      "Generation 1 || average metric: 2.25, best metric: 3.0, best parameter combination: ['a=2', 'b=1']\n",
-      "\n",
-      "Generation 2 || average metric: 2.75, best metric: 3.0, best parameter combination: ['a=2', 'b=1']\n",
-      "\n",
-      "Generation 3 || average metric: 2.75, best metric: 3.0, best parameter combination: ['a=2', 'b=1']\n",
-      "\n",
-      "Generation 4 || average metric: 2.91666666667, best metric: 3.0, best parameter combination: ['a=2', 'b=1']\n",
-      "\n",
-      "Generation 5 || average metric: 2.91666666667, best metric: 3.0, best parameter combination: ['a=2', 'b=1']\n",
-      "\n",
-      "Generation 6 || average metric: 3.0, best metric: 3.0, best parameter combination: ['a=2', 'b=1']\n",
-      "\n",
-      "Generation 7 || average metric: 3.0, best metric: 3.0, best parameter combination: ['a=2', 'b=1']\n",
-      "\n",
-      "Generation 8 || average metric: 3.0, best metric: 3.0, best parameter combination: ['a=2', 'b=1']\n",
-      "\n",
-      "Finished Experiment"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "logdir1, result_dict1 = experiment.differential_evolution(parameter_wrapper, {'a': [1,2], 'b': [-1,1]}, local_logdir=True, direction='max', generations=8, population=12)\n",
     "assert int(result_dict1['a']) == 2 and int(result_dict1['b']) == 1"
@@ -375,35 +213,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generation 0 || average metric: 1.1, best metric: 0.0, best parameter combination: ['a=1', 'b=-1']\n",
-      "\n",
-      "Generation 1 || average metric: 0.8, best metric: 0.0, best parameter combination: ['a=1', 'b=-1']\n",
-      "\n",
-      "Generation 2 || average metric: 0.4, best metric: 0.0, best parameter combination: ['a=1', 'b=-1']\n",
-      "\n",
-      "Generation 3 || average metric: 0.4, best metric: 0.0, best parameter combination: ['a=1', 'b=-1']\n",
-      "\n",
-      "Generation 4 || average metric: 0.3, best metric: 0.0, best parameter combination: ['a=1', 'b=-1']\n",
-      "\n",
-      "Generation 5 || average metric: 0.2, best metric: 0.0, best parameter combination: ['a=1', 'b=-1']\n",
-      "\n",
-      "Generation 6 || average metric: 0.0, best metric: 0.0, best parameter combination: ['a=1', 'b=-1']\n",
-      "\n",
-      "Generation 7 || average metric: 0.0, best metric: 0.0, best parameter combination: ['a=1', 'b=-1']\n",
-      "\n",
-      "Generation 8 || average metric: 0.0, best metric: 0.0, best parameter combination: ['a=1', 'b=-1']\n",
-      "\n",
-      "Finished Experiment"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "logdir2, result_dict2 = experiment.differential_evolution(parameter_wrapper, {'a': [1,2], 'b': [-1,1]}, generations=8, population=10, direction='min')\n",
     "assert int(result_dict2['a']) == 1 and int(result_dict2['b']) == -1"
@@ -427,6 +239,7 @@
     "- `hdfs.project_path()`\n",
     "- `hdfs.exists()`\n",
     "- `hdfs.load()`\n",
+    "- `hdfs.copy_to_hdfs()`\n",
     "- `hdfs.copy_to_local()`\n",
     "- `hdfs.ls()`\n",
     "- `hdfs.lsl()`\n",
@@ -434,7 +247,10 @@
     "- `hdfs.cp()`\n",
     "- `hdfs.rmr()`\n",
     "- `hdfs.rename()`\n",
-    "- `hdfs.stat()`"
+    "- `hdfs.stat()`\n",
+    "- `hdfs.isdir()`\n",
+    "- `hdfs.isfile()`\n",
+    "- `hdfs.add_py_file()`"
    ]
   },
   {
@@ -486,10 +302,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open('test.txt', 'w') as f:\n",
-    "    f.write(\"test\")\n",
-    "hdfs.copy_to_hdfs(\"test.txt\", \"Resources/test.txt\", overwrite=True)\n",
-    "assert hdfs.exists(\"Resources/test.txt\")"
+    "# copy_to_hdfs file\n",
+    "\n",
+    "with open('upload.txt', 'w') as f:\n",
+    "    f.write(\"first upload\")\n",
+    "hdfs.copy_to_hdfs(\"upload.txt\", \"Resources\")\n",
+    "assert hdfs.exists(\"Resources/upload.txt\")\n",
+    "hdfs_copied_file = hdfs.load(\"Resources/upload.txt\")\n",
+    "assert \"first upload\" == hdfs_copied_file.decode(\"utf-8\"), \"first content does not match\"\n",
+    "\n",
+    "with open('upload.txt', 'w') as f:\n",
+    "    f.write(\"second upload\")\n",
+    "hdfs.copy_to_hdfs(\"upload.txt\", \"Resources/upload.txt\", overwrite=True)\n",
+    "assert hdfs.exists(\"Resources/upload.txt\")\n",
+    "hdfs_copied_file = hdfs.load(\"Resources/upload.txt\")\n",
+    "assert \"second upload\" == hdfs_copied_file.decode(\"utf-8\"), \"second content does not match\"\n",
+    "\n",
+    "try:\n",
+    "    hdfs.copy_to_hdfs(\"upload.txt\", \"Resources\")\n",
+    "    assert False\n",
+    "except IOError:\n",
+    "    pass"
    ]
   },
   {
@@ -498,13 +331,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hdfs.copy_to_local(\"Resources/test.txt\", \"\", overwrite=True)\n",
-    "hdfs_copied_file = hdfs.load(\"Resources/test.txt\")\n",
-    "with open('test.txt', 'r') as f:\n",
+    "# copy_to_hdfs directory\n",
+    "\n",
+    "os.mkdir(\"upload_dir\")\n",
+    "assert not hdfs.exists(\"Resources/upload_dir\")\n",
+    "with open('upload_dir/upload.txt', 'w') as f:\n",
+    "    f.write(\"first upload\")\n",
+    "hdfs.copy_to_hdfs(\"upload_dir\", \"Resources\")\n",
+    "hdfs_copied_file = hdfs.load(\"Resources/upload_dir/upload.txt\")\n",
+    "assert hdfs.exists(\"Resources/upload_dir\")\n",
+    "with open('upload_dir/upload.txt', 'r') as f:\n",
     "    local_copied_file = f.read()\n",
-    "assert hdfs_copied_file.decode(\"utf-8\") == \"test\"\n",
-    "assert local_copied_file == \"test\"\n",
-    "assert hdfs.ls(\"Logs/\").__class__.__name__ == 'list'"
+    "assert hdfs_copied_file.decode(\"utf-8\") == local_copied_file, \"first content compare failed\"\n",
+    "\n",
+    "with open('upload_dir/upload.txt', 'w') as f:\n",
+    "    f.write(\"second upload\")\n",
+    "hdfs.copy_to_hdfs(\"upload_dir\", \"Resources\", overwrite=True)\n",
+    "hdfs_copied_file = hdfs.load(\"Resources/upload_dir/upload.txt\")\n",
+    "assert hdfs.exists(\"Resources/upload_dir\")\n",
+    "with open('upload_dir/upload.txt', 'r') as f:\n",
+    "    local_copied_file = f.read()\n",
+    "assert hdfs_copied_file.decode(\"utf-8\") == local_copied_file, \"second content compare failed\""
    ]
   },
   {
@@ -513,9 +360,87 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hdfs.copy_to_local(\"Logs\", \"\", overwrite=True)\n",
-    "assert os.path.exists(\"Logs\")\n",
-    "assert os.path.isdir(\"Logs\")"
+    "#copy_to_local file\n",
+    "\n",
+    "# Download first time\n",
+    "assert not os.path.exists(\"somefile.txt\")\n",
+    "hdfs.dump(\"initial content\", \"Resources/somefile.txt\")\n",
+    "hdfs.copy_to_local(\"Resources/somefile.txt\")\n",
+    "hdfs_copied_file = hdfs.load(\"Resources/somefile.txt\")\n",
+    "with open('somefile.txt', 'r') as f:\n",
+    "    local_copied_file = f.read()\n",
+    "assert hdfs_copied_file.decode(\"utf-8\") == local_copied_file, \"first content compare failed\"\n",
+    "first_modified = os.path.getmtime(\"somefile.txt\")\n",
+    "\n",
+    "# Download second time\n",
+    "hdfs.copy_to_local(\"Resources/somefile.txt\")\n",
+    "hdfs_copied_file = hdfs.load(\"Resources/somefile.txt\")\n",
+    "with open('somefile.txt', 'r') as f:\n",
+    "    local_copied_file = f.read()\n",
+    "assert hdfs_copied_file.decode(\"utf-8\") == local_copied_file, \"second content compare failed\"\n",
+    "second_modified = os.path.getmtime(\"somefile.txt\")\n",
+    "assert first_modified == second_modified, \"modified time not matching\"\n",
+    "\n",
+    "# Content changing on disk\n",
+    "hdfs.dump(\"content changed at some point\", \"Resources/somefile.txt\")\n",
+    "hdfs_new_content = hdfs.load(\"Resources/somefile.txt\")\n",
+    "hdfs.copy_to_local(\"Resources/somefile.txt\")\n",
+    "with open('somefile.txt', 'r') as f:\n",
+    "    local_copied_file = f.read()\n",
+    "assert hdfs_new_content.decode(\"utf-8\") == local_copied_file, \"third content compare failed\"\n",
+    "third_modified = os.path.getmtime(\"somefile.txt\")\n",
+    "assert not second_modified == third_modified, \"modified time not matching\"\n",
+    "\n",
+    "# Download last time with overwrite, file should have changed on disk\n",
+    "hdfs.copy_to_local(\"Resources/somefile.txt\", overwrite=True)\n",
+    "hdfs_copied_file = hdfs.load(\"Resources/somefile.txt\")\n",
+    "with open('somefile.txt', 'r') as f:\n",
+    "    local_copied_file = f.read()\n",
+    "assert hdfs_copied_file.decode(\"utf-8\") == local_copied_file, \"fourth content compare failed\"\n",
+    "fourth_modified = os.path.getmtime(\"somefile.txt\")\n",
+    "assert not third_modified == fourth_modified, \"modified time not matching\"\n",
+    "\n",
+    "# Download again to make sure overwrite did not cause problems\n",
+    "hdfs.copy_to_local(\"Resources/somefile.txt\")\n",
+    "hdfs_copied_file = hdfs.load(\"Resources/somefile.txt\")\n",
+    "with open('somefile.txt', 'r') as f:\n",
+    "    local_copied_file = f.read()\n",
+    "assert hdfs_copied_file.decode(\"utf-8\") == local_copied_file, \"fifth content compare failed\"\n",
+    "fifth_modified = os.path.getmtime(\"somefile.txt\")\n",
+    "assert fourth_modified == fifth_modified, \"modified time not matching\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#copy_to_local directory\n",
+    "\n",
+    "assert not os.path.exists(\"Resources\")\n",
+    "hdfs.copy_to_local(\"Resources\")\n",
+    "first_modified = os.path.getmtime(\"Resources\")\n",
+    "assert os.path.exists(\"Resources\")\n",
+    "assert os.path.isdir(\"Resources\")\n",
+    "\n",
+    "hdfs.copy_to_local(\"Resources\")\n",
+    "second_modified = os.path.getmtime(\"Resources\")\n",
+    "assert first_modified == second_modified\n",
+    "\n",
+    "localized_dir = hdfs.copy_to_local(\"Resources\", overwrite=True)\n",
+    "third_modified = os.path.getmtime(\"Resources\")\n",
+    "assert not second_modified == third_modified\n",
+    "num_files_first = len(os.listdir(localized_dir))\n",
+    "\n",
+    "# Add a new file, it should also be localized\n",
+    "hdfs.dump(\"a wild file appeared\", \"Resources/newfile.txt\")\n",
+    "hdfs.copy_to_local(\"Resources\")\n",
+    "fourth_modified = os.path.getmtime(\"Resources\")\n",
+    "assert first_modified == second_modified\n",
+    "num_files_second = len(os.listdir(localized_dir))\n",
+    "assert (num_files_first + 1) == num_files_second\n",
+    "assert not third_modified == fourth_modified"
    ]
   },
   {
@@ -537,6 +462,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "hdfs.dump(\"dummy\", \"Resources/test.txt\")\n",
     "hdfs.cp(\"Resources/test.txt\", \"Logs/\")\n",
     "logs_files = hdfs.ls(\"Logs/\")\n",
     "assert \"test.txt\" in \",\".join(logs_files)"
@@ -643,10 +569,43 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert hdfs.isdir(\"Resources\")\n",
+    "assert not hdfs.isdir(\"Resources/README.md\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert hdfs.isfile(\"Resources/README.md\")\n",
+    "assert not hdfs.isfile(\"Resources\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdfs.dump(\"def simple():\\n\\treturn 5\", \"Resources/my_module.py\")\n",
+    "py_path = hdfs.add_py_file(\"Resources/my_module.py\")\n",
+    "assert py_path in sys.path\n",
+    "import my_module\n",
+    "assert my_module.simple() == 5"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Training Tests"
+    "### Experiment API Tests"
    ]
   },
   {
@@ -698,7 +657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -709,38 +668,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finished Experiment \n",
-      "\n",
-      "u'hdfs://10.0.2.15:8020/Projects/project_bde67d4d2ef6dcfc/Experiments/application_1552647327939_0019/collective_all_reduce/run.1'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "experiment.collective_all_reduce(collective, local_logdir=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finished Experiment \n",
-      "\n",
-      "u'hdfs://10.0.2.15:8020/Projects/project_bde67d4d2ef6dcfc/Experiments/application_1552647327939_0019/collective_all_reduce/run.2'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "experiment.collective_all_reduce(collective, name='collectivetime', description='such desc', local_logdir=False)"
    ]
@@ -756,7 +695,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -767,7 +706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -777,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -786,7 +725,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -811,15 +750,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "spark = util._find_spark()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -828,7 +758,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -845,22 +775,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "computing descriptive statistics for : games_features\n",
-      "computing feature correlation for: games_features\n",
-      "computing feature histograms for: games_features\n",
-      "computing cluster analysis for: games_features\n",
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Feature group created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_featuregroup(\n",
     "    games_features_df,\n",
@@ -871,22 +788,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "computing descriptive statistics for : teams_features\n",
-      "computing feature correlation for: teams_features\n",
-      "computing feature histograms for: teams_features\n",
-      "computing cluster analysis for: teams_features\n",
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Feature group created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_featuregroup(\n",
     "    teams_features_df,\n",
@@ -897,22 +801,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "computing descriptive statistics for : season_scores_features\n",
-      "computing feature correlation for: season_scores_features\n",
-      "computing feature histograms for: season_scores_features\n",
-      "computing cluster analysis for: season_scores_features\n",
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Feature group created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_featuregroup(\n",
     "    season_scores_features_df,\n",
@@ -923,22 +814,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "computing descriptive statistics for : attendances_features\n",
-      "computing feature correlation for: attendances_features\n",
-      "computing feature histograms for: attendances_features\n",
-      "computing cluster analysis for: attendances_features\n",
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Feature group created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_featuregroup(\n",
     "    attendances_features_df,\n",
@@ -949,18 +827,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM teams_features_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "teams_features_1_df = featurestore.get_featuregroup(\"teams_features\")\n",
     "teams_features_2_df = teams_features_1_df.withColumnRenamed(\n",
@@ -971,18 +840,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Feature group created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_featuregroup(\n",
     "    teams_features_2_df,\n",
@@ -997,18 +857,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Feature group created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_featuregroup(\n",
     "    teams_features_2_df,\n",
@@ -1027,18 +878,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Feature group created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_featuregroup(\n",
     "    teams_features_2_df,\n",
@@ -1054,7 +896,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1080,24 +922,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{u'trainingDatasets': [], u'featuregroups': [{u'lastComputed': None, u'featuresHistogram': {u'featureDistributions': [{u'frequencyDistribution': [{u'bin': u'37.75', u'frequency': 3}, {u'bin': u'3.45', u'frequency': 2}, {u'bin': u'1.0', u'frequency': 6}, {u'bin': u'20.6', u'frequency': 2}, {u'bin': u'15.7', u'frequency': 0}, {u'bin': u'40.2', u'frequency': 1}, {u'bin': u'5.9', u'frequency': 4}, {u'bin': u'27.95', u'frequency': 0}, {u'bin': u'47.55', u'frequency': 4}, {u'bin': u'30.4', u'frequency': 4}, {u'bin': u'23.05', u'frequency': 1}, {u'bin': u'8.35', u'frequency': 2}, {u'bin': u'35.3', u'frequency': 1}, {u'bin': u'25.5', u'frequency': 3}, {u'bin': u'10.8', u'frequency': 5}, {u'bin': u'13.25', u'frequency': 4}, {u'bin': u'18.15', u'frequency': 0}, {u'bin': u'32.85', u'frequency': 3}, {u'bin': u'45.1', u'frequency': 2}, {u'bin': u'42.65', u'frequency': 2}], u'statisticType': u'featureDistributions', u'featureName': u'away_team_id'}, {u'frequencyDistribution': [{u'bin': u'37.75', u'frequency': 2}, {u'bin': u'3.45', u'frequency': 3}, {u'bin': u'1.0', u'frequency': 2}, {u'bin': u'20.6', u'frequency': 0}, {u'bin': u'15.7', u'frequency': 0}, {u'bin': u'40.2', u'frequency': 2}, {u'bin': u'5.9', u'frequency': 2}, {u'bin': u'27.95', u'frequency': 4}, {u'bin': u'47.55', u'frequency': 4}, {u'bin': u'30.4', u'frequency': 3}, {u'bin': u'23.05', u'frequency': 2}, {u'bin': u'8.35', u'frequency': 2}, {u'bin': u'35.3', u'frequency': 0}, {u'bin': u'25.5', u'frequency': 4}, {u'bin': u'10.8', u'frequency': 4}, {u'bin': u'13.25', u'frequency': 3}, {u'bin': u'18.15', u'frequency': 3}, {u'bin': u'32.85', u'frequency': 3}, {u'bin': u'45.1', u'frequency': 2}, {u'bin': u'42.65', u'frequency': 4}], u'statisticType': u'featureDistributions', u'featureName': u'home_team_id'}, {u'frequencyDistribution': [{u'bin': u'1.4', u'frequency': 0}, {u'bin': u'1.5', u'frequency': 0}, {u'bin': u'1.6', u'frequency': 0}, {u'bin': u'1.7', u'frequency': 0}, {u'bin': u'1.0', u'frequency': 25}, {u'bin': u'1.1', u'frequency': 0}, {u'bin': u'1.2', u'frequency': 0}, {u'bin': u'1.3', u'frequency': 0}, {u'bin': u'1.8', u'frequency': 0}, {u'bin': u'1.9', u'frequency': 0}, {u'bin': u'2.9', u'frequency': 18}, {u'bin': u'2.8', u'frequency': 0}, {u'bin': u'2.3', u'frequency': 0}, {u'bin': u'2.2', u'frequency': 0}, {u'bin': u'2.1', u'frequency': 0}, {u'bin': u'2.0', u'frequency': 6}, {u'bin': u'2.7', u'frequency': 0}, {u'bin': u'2.6', u'frequency': 0}, {u'bin': u'2.5', u'frequency': 0}, {u'bin': u'2.4', u'frequency': 0}], u'statisticType': u'featureDistributions', u'featureName': u'score'}]}, u'description': u'Features of average season scores for football teams', u'name': u'games_features', u'created': u'2019-03-19T14:17:20Z', u'featurestoreId': 22, u'descriptiveStatistics': {u'descriptiveStats': [{u'metricValues': [{u'value': 49.0, u'metricName': u'count'}, {u'value': 26.591837, u'metricName': u'mean'}, {u'value': 14.802756, u'metricName': u'stddev'}, {u'value': 1.0, u'metricName': u'min'}, {u'value': 50.0, u'metricName': u'max'}], u'statisticType': u'descriptiveStatistics', u'featureName': u'home_team_id'}, {u'metricValues': [{u'value': 49.0, u'metricName': u'count'}, {u'value': 1.8571428, u'metricName': u'mean'}, {u'value': 0.9354144, u'metricName': u'stddev'}, {u'value': 1.0, u'metricName': u'min'}, {u'value': 3.0, u'metricName': u'max'}], u'statisticType': u'descriptiveStatistics', u'featureName': u'score'}, {u'metricValues': [{u'value': 49.0, u'metricName': u'count'}, {u'value': 23.081633, u'metricName': u'mean'}, {u'value': 15.90445, u'metricName': u'stddev'}, {u'value': 1.0, u'metricName': u'min'}, {u'value': 50.0, u'metricName': u'max'}], u'statisticType': u'descriptiveStatistics', u'featureName': u'away_team_id'}]}, u'creator': u'4f67e02d354864382be24f160c9dd50c03db1bcd@email.com', u'jobName': None, u'jobStatus': None, u'clusterAnalysis': {u'clusters': [{u'cluster': 3, u'datapointName': u'42'}, {u'cluster': 0, u'datapointName': u'48'}, {u'cluster': 4, u'datapointName': u'43'}, {u'cluster': 4, u'datapointName': u'24'}, {u'cluster': 1, u'datapointName': u'25'}, {u'cluster': 3, u'datapointName': u'26'}, {u'cluster': 2, u'datapointName': u'27'}, {u'cluster': 4, u'datapointName': u'20'}, {u'cluster': 4, u'datapointName': u'21'}, {u'cluster': 0, u'datapointName': u'22'}, {u'cluster': 0, u'datapointName': u'23'}, {u'cluster': 0, u'datapointName': u'46'}, {u'cluster': 2, u'datapointName': u'47'}, {u'cluster': 4, u'datapointName': u'44'}, {u'cluster': 0, u'datapointName': u'45'}, {u'cluster': 0, u'datapointName': u'28'}, {u'cluster': 1, u'datapointName': u'29'}, {u'cluster': 1, u'datapointName': u'40'}, {u'cluster': 4, u'datapointName': u'41'}, {u'cluster': 4, u'datapointName': u'1'}, {u'cluster': 0, u'datapointName': u'0'}, {u'cluster': 0, u'datapointName': u'3'}, {u'cluster': 3, u'datapointName': u'2'}, {u'cluster': 0, u'datapointName': u'5'}, {u'cluster': 2, u'datapointName': u'4'}, {u'cluster': 3, u'datapointName': u'7'}, {u'cluster': 1, u'datapointName': u'6'}, {u'cluster': 0, u'datapointName': u'9'}, {u'cluster': 1, u'datapointName': u'8'}, {u'cluster': 2, u'datapointName': u'39'}, {u'cluster': 3, u'datapointName': u'38'}, {u'cluster': 2, u'datapointName': u'11'}, {u'cluster': 0, u'datapointName': u'10'}, {u'cluster': 0, u'datapointName': u'13'}, {u'cluster': 1, u'datapointName': u'12'}, {u'cluster': 0, u'datapointName': u'15'}, {u'cluster': 3, u'datapointName': u'14'}, {u'cluster': 3, u'datapointName': u'17'}, {u'cluster': 3, u'datapointName': u'16'}, {u'cluster': 1, u'datapointName': u'19'}, {u'cluster': 1, u'datapointName': u'18'}, {u'cluster': 1, u'datapointName': u'31'}, {u'cluster': 4, u'datapointName': u'30'}, {u'cluster': 0, u'datapointName': u'37'}, {u'cluster': 1, u'datapointName': u'36'}, {u'cluster': 2, u'datapointName': u'35'}, {u'cluster': 2, u'datapointName': u'34'}, {u'cluster': 2, u'datapointName': u'33'}, {u'cluster': 3, u'datapointName': u'32'}], u'statisticType': u'clusterAnalysis', u'dataPoints': [{u'datapointName': u'42', u'firstDimension': -10.123179, u'secondDimension': -14.630445}, {u'datapointName': u'48', u'firstDimension': -1.1187825, u'secondDimension': -29.083815}, {u'datapointName': u'43', u'firstDimension': -46.13057, u'secondDimension': -31.045153}, {u'datapointName': u'24', u'firstDimension': -42.010517, u'secondDimension': -32.770252}, {u'datapointName': u'25', u'firstDimension': -36.023994, u'secondDimension': -46.46312}, {u'datapointName': u'26', u'firstDimension': -6.728213, u'secondDimension': -5.3871393}, {u'datapointName': u'27', u'firstDimension': -47.984543, u'secondDimension': -18.149778}, {u'datapointName': u'20', u'firstDimension': -32.23772, u'secondDimension': -29.105984}, {u'datapointName': u'21', u'firstDimension': -30.70503, u'secondDimension': -21.991512}, {u'datapointName': u'22', u'firstDimension': -7.1011095, u'secondDimension': -29.487545}, {u'datapointName': u'23', u'firstDimension': -0.8551152, u'secondDimension': -33.072327}, {u'datapointName': u'46', u'firstDimension': 0.7434928, u'secondDimension': -26.95498}, {u'datapointName': u'47', u'firstDimension': -30.762646, u'secondDimension': -5.9701777}, {u'datapointName': u'44', u'firstDimension': -31.702085, u'secondDimension': -22.0588}, {u'datapointName': u'45', u'firstDimension': -1.38245, u'secondDimension': -25.095303}, {u'datapointName': u'28', u'firstDimension': -0.7315832, u'secondDimension': -50.090786}, {u'datapointName': u'29', u'firstDimension': -18.011095, u'secondDimension': -46.249054}, {u'datapointName': u'40', u'firstDimension': -20.862122, u'secondDimension': -33.42097}, {u'datapointName': u'41', u'firstDimension': -47.729176, u'secondDimension': -37.1625}, {u'datapointName': u'1', u'firstDimension': -43.87279, u'secondDimension': -34.899086}, {u'datapointName': u'0', u'firstDimension': -7.8427987, u'secondDimension': -48.56755}, {u'datapointName': u'3', u'firstDimension': -7.9087152, u'secondDimension': -47.570423}, {u'datapointName': u'2', u'firstDimension': -14.177314, u'secondDimension': -13.902471}, {u'datapointName': u'5', u'firstDimension': -8.427749, u'secondDimension': -24.569195}, {u'datapointName': u'4', u'firstDimension': -49.904434, u'secondDimension': -4.2572775}, {u'datapointName': u'7', u'firstDimension': -13.549052, u'secondDimension': -8.814783}, {u'datapointName': u'6', u'firstDimension': -33.401623, u'secondDimension': -41.240856}, {u'datapointName': u'9', u'firstDimension': -3.9781125, u'secondDimension': -31.279936}, {u'datapointName': u'8', u'firstDimension': -34.76327, u'secondDimension': -50.384342}, {u'datapointName': u'39', u'firstDimension': -25.184122, u'secondDimension': -14.607885}, {u'datapointName': u'38', u'firstDimension': -13.18026, u'secondDimension': -13.835182}, {u'datapointName': u'11', u'firstDimension': -42.7273, u'secondDimension': -6.777641}, {u'datapointName': u'10', u'firstDimension': -1.3165331, u'secondDimension': -26.09243}, {u'datapointName': u'13', u'firstDimension': -1.3248348, u'secondDimension': -41.11664}, {u'datapointName': u'12', u'firstDimension': -35.89216, u'secondDimension': -48.45738}, {u'datapointName': u'15', u'firstDimension': -11.822715, u'secondDimension': -33.8125}, {u'datapointName': u'14', u'firstDimension': -11.682579, u'secondDimension': -20.782549}, {u'datapointName': u'17', u'firstDimension': -7.026891, u'secondDimension': -15.460466}, {u'datapointName': u'16', u'firstDimension': -1.505982, u'secondDimension': -8.07684}, {u'datapointName': u'19', u'firstDimension': -24.191172, u'secondDimension': -43.661404}, {u'datapointName': u'18', u'firstDimension': -21.331842, u'secondDimension': -41.465282}, {u'datapointName': u'31', u'firstDimension': -43.97372, u'secondDimension': -47.9638}, {u'datapointName': u'30', u'firstDimension': -32.23772, u'secondDimension': -29.105984}, {u'datapointName': u'37', u'firstDimension': -9.705074, u'secondDimension': -50.696384}, {u'datapointName': u'36', u'firstDimension': -23.993422, u'secondDimension': -46.652786}, {u'datapointName': u'35', u'firstDimension': -40.33769, u'secondDimension': -12.625831}, {u'datapointName': u'34', u'firstDimension': -30.367146, u'secondDimension': -11.952945}, {u'datapointName': u'33', u'firstDimension': -30.235312, u'secondDimension': -13.947201}, {u'datapointName': u'32', u'firstDimension': -8.028143, u'secondDimension': -1.4311563}]}, u'inodeId': 106555, u'featurestoreName': u'project_bde67d4d2ef6dcfc_featurestore', u'hdfsStorePaths': [u'hdfs://10.0.2.15:8020/apps/hive/warehouse/project_bde67d4d2ef6dcfc_featurestore.db/games_features_1'], u'dependencies': [], u'version': 1, u'featureCorrelationMatrix': {u'featureCorrelations': [{u'featureName': u'score', u'correlationValues': [{u'statisticType': u'featureCorrelations', u'featureName': u'home_team_id', u'correlation': -0.5955944}, {u'statisticType': u'featureCorrelations', u'featureName': u'score', u'correlation': 1.0}, {u'statisticType': u'featureCorrelations', u'featureName': u'away_team_id', u'correlation': 0.63095695}]}, {u'featureName': u'home_team_id', u'correlationValues': [{u'statisticType': u'featureCorrelations', u'featureName': u'home_team_id', u'correlation': 1.0}, {u'statisticType': u'featureCorrelations', u'featureName': u'score', u'correlation': -0.5955944}, {u'statisticType': u'featureCorrelations', u'featureName': u'away_team_id', u'correlation': -0.00826214}]}, {u'featureName': u'away_team_id', u'correlationValues': [{u'statisticType': u'featureCorrelations', u'featureName': u'home_team_id', u'correlation': -0.00826214}, {u'statisticType': u'featureCorrelations', u'featureName': u'score', u'correlation': 0.63095695}, {u'statisticType': u'featureCorrelations', u'featureName': u'away_team_id', u'correlation': 1.0}]}]}, u'jobId': None, u'id': 1, u'features': [{u'type': u'int', u'name': u'away_team_id', u'primary': True, u'description': u'-'}, {u'type': u'int', u'name': u'home_team_id', u'primary': False, u'description': u'-'}, {u'type': u'int', u'name': u'score', u'primary': False, u'description': u'-'}]}, {u'lastComputed': None, u'featuresHistogram': {u'featureDistributions': [{u'frequencyDistribution': [{u'bin': u'7956.403935', u'frequency': 4}, {u'bin': u'2816.73891', u'frequency': 3}, {u'bin': u'15151.93497', u'frequency': 1}, {u'bin': u'6928.47093', u'frequency': 3}, {u'bin': u'20291.599995', u'frequency': 2}, {u'bin': u'8984.33694', u'frequency': 4}, {u'bin': u'5900.537925', u'frequency': 2}, {u'bin': u'760.8729', u'frequency': 7}, {u'bin': u'18235.733985', u'frequency': 0}, {u'bin': u'14124.001965', u'frequency': 3}, {u'bin': u'10012.269945', u'frequency': 2}, {u'bin': u'19263.66699', u'frequency': 0}, {u'bin': u'4872.60492', u'frequency': 2}, {u'bin': u'1788.805905', u'frequency': 2}, {u'bin': u'13096.06896', u'frequency': 1}, {u'bin': u'12068.135955', u'frequency': 8}, {u'bin': u'16179.867975', u'frequency': 1}, {u'bin': u'17207.80098', u'frequency': 0}, {u'bin': u'11040.20295', u'frequency': 3}, {u'bin': u'3844.671915', u'frequency': 2}], u'statisticType': u'featureDistributions', u'featureName': u'team_budget'}, {u'frequencyDistribution': [{u'bin': u'37.75', u'frequency': 3}, {u'bin': u'3.45', u'frequency': 2}, {u'bin': u'1.0', u'frequency': 3}, {u'bin': u'20.6', u'frequency': 3}, {u'bin': u'15.7', u'frequency': 3}, {u'bin': u'40.2', u'frequency': 2}, {u'bin': u'5.9', u'frequency': 3}, {u'bin': u'27.95', u'frequency': 3}, {u'bin': u'47.55', u'frequency': 3}, {u'bin': u'30.4', u'frequency': 2}, {u'bin': u'23.05', u'frequency': 2}, {u'bin': u'8.35', u'frequency': 2}, {u'bin': u'35.3', u'frequency': 2}, {u'bin': u'25.5', u'frequency': 2}, {u'bin': u'10.8', u'frequency': 3}, {u'bin': u'13.25', u'frequency': 2}, {u'bin': u'18.15', u'frequency': 2}, {u'bin': u'32.85', u'frequency': 3}, {u'bin': u'45.1', u'frequency': 2}, {u'bin': u'42.65', u'frequency': 3}], u'statisticType': u'featureDistributions', u'featureName': u'team_id'}, {u'frequencyDistribution': [{u'bin': u'37.75', u'frequency': 3}, {u'bin': u'3.45', u'frequency': 2}, {u'bin': u'1.0', u'frequency': 3}, {u'bin': u'20.6', u'frequency': 3}, {u'bin': u'15.7', u'frequency': 3}, {u'bin': u'40.2', u'frequency': 2}, {u'bin': u'5.9', u'frequency': 3}, {u'bin': u'27.95', u'frequency': 3}, {u'bin': u'47.55', u'frequency': 3}, {u'bin': u'30.4', u'frequency': 2}, {u'bin': u'23.05', u'frequency': 2}, {u'bin': u'8.35', u'frequency': 2}, {u'bin': u'35.3', u'frequency': 2}, {u'bin': u'25.5', u'frequency': 2}, {u'bin': u'10.8', u'frequency': 3}, {u'bin': u'13.25', u'frequency': 2}, {u'bin': u'18.15', u'frequency': 2}, {u'bin': u'32.85', u'frequency': 3}, {u'bin': u'45.1', u'frequency': 2}, {u'bin': u'42.65', u'frequency': 3}], u'statisticType': u'featureDistributions', u'featureName': u'team_position'}]}, u'description': u'a spanish version of teams_features', u'name': u'teams_features', u'created': u'2019-03-19T14:17:44Z', u'featurestoreId': 22, u'descriptiveStatistics': {u'descriptiveStats': [{u'metricValues': [{u'value': 50.0, u'metricName': u'count'}, {u'value': 8723.292, u'metricName': u'mean'}, {u'value': 5238.943, u'metricName': u'stddev'}, {u'value': 760.8729, u'metricName': u'min'}, {u'value': 21319.533, u'metricName': u'max'}], u'statisticType': u'descriptiveStatistics', u'featureName': u'team_budget'}, {u'metricValues': [{u'value': 50.0, u'metricName': u'count'}, {u'value': 25.5, u'metricName': u'mean'}, {u'value': 14.57738, u'metricName': u'stddev'}, {u'value': 1.0, u'metricName': u'min'}, {u'value': 50.0, u'metricName': u'max'}], u'statisticType': u'descriptiveStatistics', u'featureName': u'team_position'}, {u'metricValues': [{u'value': 50.0, u'metricName': u'count'}, {u'value': 25.5, u'metricName': u'mean'}, {u'value': 14.57738, u'metricName': u'stddev'}, {u'value': 1.0, u'metricName': u'min'}, {u'value': 50.0, u'metricName': u'max'}], u'statisticType': u'descriptiveStatistics', u'featureName': u'team_id'}]}, u'creator': u'4f67e02d354864382be24f160c9dd50c03db1bcd@email.com', u'jobName': None, u'jobStatus': None, u'clusterAnalysis': {u'clusters': [{u'cluster': 0, u'datapointName': u'56'}, {u'cluster': 0, u'datapointName': u'54'}, {u'cluster': 3, u'datapointName': u'42'}, {u'cluster': 2, u'datapointName': u'48'}, {u'cluster': 1, u'datapointName': u'43'}, {u'cluster': 0, u'datapointName': u'60'}, {u'cluster': 3, u'datapointName': u'61'}, {u'cluster': 2, u'datapointName': u'49'}, {u'cluster': 1, u'datapointName': u'52'}, {u'cluster': 1, u'datapointName': u'53'}, {u'cluster': 0, u'datapointName': u'24'}, {u'cluster': 0, u'datapointName': u'25'}, {u'cluster': 0, u'datapointName': u'26'}, {u'cluster': 0, u'datapointName': u'27'}, {u'cluster': 0, u'datapointName': u'20'}, {u'cluster': 2, u'datapointName': u'21'}, {u'cluster': 2, u'datapointName': u'22'}, {u'cluster': 0, u'datapointName': u'23'}, {u'cluster': 4, u'datapointName': u'46'}, {u'cluster': 4, u'datapointName': u'47'}, {u'cluster': 1, u'datapointName': u'44'}, {u'cluster': 1, u'datapointName': u'45'}, {u'cluster': 0, u'datapointName': u'28'}, {u'cluster': 0, u'datapointName': u'29'}, {u'cluster': 2, u'datapointName': u'40'}, {u'cluster': 2, u'datapointName': u'41'}, {u'cluster': 0, u'datapointName': u'1'}, {u'cluster': 0, u'datapointName': u'0'}, {u'cluster': 1, u'datapointName': u'3'}, {u'cluster': 1, u'datapointName': u'2'}, {u'cluster': 1, u'datapointName': u'5'}, {u'cluster': 1, u'datapointName': u'4'}, {u'cluster': 2, u'datapointName': u'7'}, {u'cluster': 1, u'datapointName': u'6'}, {u'cluster': 3, u'datapointName': u'9'}, {u'cluster': 0, u'datapointName': u'8'}, {u'cluster': 1, u'datapointName': u'51'}, {u'cluster': 1, u'datapointName': u'39'}, {u'cluster': 1, u'datapointName': u'38'}, {u'cluster': 0, u'datapointName': u'59'}, {u'cluster': 0, u'datapointName': u'58'}, {u'cluster': 3, u'datapointName': u'11'}, {u'cluster': 3, u'datapointName': u'10'}, {u'cluster': 1, u'datapointName': u'13'}, {u'cluster': 2, u'datapointName': u'12'}, {u'cluster': 1, u'datapointName': u'15'}, {u'cluster': 1, u'datapointName': u'14'}, {u'cluster': 0, u'datapointName': u'17'}, {u'cluster': 4, u'datapointName': u'16'}, {u'cluster': 0, u'datapointName': u'19'}, {u'cluster': 0, u'datapointName': u'18'}, {u'cluster': 2, u'datapointName': u'31'}, {u'cluster': 2, u'datapointName': u'30'}, {u'cluster': 2, u'datapointName': u'37'}, {u'cluster': 1, u'datapointName': u'36'}, {u'cluster': 1, u'datapointName': u'35'}, {u'cluster': 3, u'datapointName': u'34'}, {u'cluster': 2, u'datapointName': u'33'}, {u'cluster': 0, u'datapointName': u'55'}, {u'cluster': 2, u'datapointName': u'32'}, {u'cluster': 0, u'datapointName': u'57'}, {u'cluster': 1, u'datapointName': u'50'}], u'statisticType': u'clusterAnalysis', u'dataPoints': [{u'datapointName': u'56', u'firstDimension': -11169.978, u'secondDimension': -65.27653}, {u'datapointName': u'54', u'firstDimension': -12510.703, u'secondDimension': -62.47483}, {u'datapointName': u'42', u'firstDimension': -14580.947, u'secondDimension': -51.202396}, {u'datapointName': u'48', u'firstDimension': -910.39215, u'secondDimension': -56.586693}, {u'datapointName': u'43', u'firstDimension': -9290.637, u'secondDimension': -52.511135}, {u'datapointName': u'60', u'firstDimension': -11296.575, u'secondDimension': -68.107475}, {u'datapointName': u'61', u'firstDimension': -14551.416, u'secondDimension': -69.586586}, {u'datapointName': u'49', u'firstDimension': -1583.59, u'secondDimension': -58.014328}, {u'datapointName': u'52', u'firstDimension': -9775.454, u'secondDimension': -59.59187}, {u'datapointName': u'53', u'firstDimension': -9775.454, u'secondDimension': -59.59187}, {u'datapointName': u'24', u'firstDimension': -12494.655, u'secondDimension': -29.947598}, {u'datapointName': u'25', u'firstDimension': -12433.237, u'secondDimension': -31.360586}, {u'datapointName': u'26', u'firstDimension': -12433.237, u'secondDimension': -31.360586}, {u'datapointName': u'27', u'firstDimension': -12433.237, u'secondDimension': -31.360586}, {u'datapointName': u'20', u'firstDimension': -11698.139, u'secondDimension': -20.03222}, {u'datapointName': u'21', u'firstDimension': -1621.1931, u'secondDimension': -24.073954}, {u'datapointName': u'22', u'firstDimension': -1621.1931, u'secondDimension': -24.073954}, {u'datapointName': u'23', u'firstDimension': -13022.44, u'secondDimension': -27.129692}, {u'datapointName': u'46', u'firstDimension': -20347.28, u'secondDimension': -55.56}, {u'datapointName': u'47', u'firstDimension': -20347.28, u'secondDimension': -55.56}, {u'datapointName': u'44', u'firstDimension': -9290.637, u'secondDimension': -52.511135}, {u'datapointName': u'45', u'firstDimension': -9290.637, u'secondDimension': -52.511135}, {u'datapointName': u'28', u'firstDimension': -12433.237, u'secondDimension': -31.360586}, {u'datapointName': u'29', u'firstDimension': -10290.322, u'secondDimension': -32.732075}, {u'datapointName': u'40', u'firstDimension': -1587.0887, u'secondDimension': -48.114902}, {u'datapointName': u'41', u'firstDimension': -787.9128, u'secondDimension': -49.513184}, {u'datapointName': u'1', u'firstDimension': -13547.429, u'secondDimension': -5.926956}, {u'datapointName': u'0', u'firstDimension': -13547.429, u'secondDimension': -5.926956}, {u'datapointName': u'3', u'firstDimension': -7307.94, u'secondDimension': -8.630983}, {u'datapointName': u'2', u'firstDimension': -9678.333, u'secondDimension': -7.26403}, {u'datapointName': u'5', u'firstDimension': -9469.991, u'secondDimension': -10.088303}, {u'datapointName': u'4', u'firstDimension': -9469.991, u'secondDimension': -10.088303}, {u'datapointName': u'7', u'firstDimension': -2248.776, u'secondDimension': -11.358543}, {u'datapointName': u'6', u'firstDimension': -9469.991, u'secondDimension': -10.088303}, {u'datapointName': u'9', u'firstDimension': -16107.08, u'secondDimension': -14.463271}, {u'datapointName': u'8', u'firstDimension': -12474.419, u'secondDimension': -12.976631}, {u'datapointName': u'51', u'firstDimension': -9775.454, u'secondDimension': -59.59187}, {u'datapointName': u'39', u'firstDimension': -8154.7246, u'secondDimension': -46.83163}, {u'datapointName': u'38', u'firstDimension': -8154.7246, u'secondDimension': -46.83163}, {u'datapointName': u'59', u'firstDimension': -11296.575, u'secondDimension': -68.107475}, {u'datapointName': u'58', u'firstDimension': -11169.978, u'secondDimension': -65.27653}, {u'datapointName': u'11', u'firstDimension': -16107.08, u'secondDimension': -14.463271}, {u'datapointName': u'10', u'firstDimension': -16107.08, u'secondDimension': -14.463271}, {u'datapointName': u'13', u'firstDimension': -6101.9717, u'secondDimension': -17.09222}, {u'datapointName': u'12', u'firstDimension': -4888.232, u'secondDimension': -15.653809}, {u'datapointName': u'15', u'firstDimension': -6101.9717, u'secondDimension': -17.09222}, {u'datapointName': u'14', u'firstDimension': -6101.9717, u'secondDimension': -17.09222}, {u'datapointName': u'17', u'firstDimension': -11698.139, u'secondDimension': -20.03222}, {u'datapointName': u'16', u'firstDimension': -21319.533, u'secondDimension': -18.809835}, {u'datapointName': u'19', u'firstDimension': -11698.139, u'secondDimension': -20.03222}, {u'datapointName': u'18', u'firstDimension': -11698.139, u'secondDimension': -20.03222}, {u'datapointName': u'31', u'firstDimension': -930.39667, u'secondDimension': -35.37389}, {u'datapointName': u'30', u'firstDimension': -760.87225, u'secondDimension': -33.956295}, {u'datapointName': u'37', u'firstDimension': -4969.734, u'secondDimension': -45.35392}, {u'datapointName': u'36', u'firstDimension': -6907.281, u'secondDimension': -42.56412}, {u'datapointName': u'35', u'firstDimension': -6907.281, u'secondDimension': -42.56412}, {u'datapointName': u'34', u'firstDimension': -16758.064, u'secondDimension': -37.10367}, {u'datapointName': u'33', u'firstDimension': -930.39667, u'secondDimension': -35.37389}, {u'datapointName': u'55', u'firstDimension': -12510.703, u'secondDimension': -62.47483}, {u'datapointName': u'32', u'firstDimension': -930.39667, u'secondDimension': -35.37389}, {u'datapointName': u'57', u'firstDimension': -11169.978, u'secondDimension': -65.27653}, {u'datapointName': u'50', u'firstDimension': -9775.454, u'secondDimension': -59.59187}]}, u'inodeId': 106570, u'featurestoreName': u'project_bde67d4d2ef6dcfc_featurestore', u'hdfsStorePaths': [u'hdfs://10.0.2.15:8020/apps/hive/warehouse/project_bde67d4d2ef6dcfc_featurestore.db/teams_features_1'], u'dependencies': [], u'version': 1, u'featureCorrelationMatrix': {u'featureCorrelations': [{u'featureName': u'team_position', u'correlationValues': [{u'statisticType': u'featureCorrelations', u'featureName': u'team_budget', u'correlation': 0.058723483}, {u'statisticType': u'featureCorrelations', u'featureName': u'team_position', u'correlation': 1.0}, {u'statisticType': u'featureCorrelations', u'featureName': u'team_id', u'correlation': 1.0}]}, {u'featureName': u'team_budget', u'correlationValues': [{u'statisticType': u'featureCorrelations', u'featureName': u'team_budget', u'correlation': 1.0}, {u'statisticType': u'featureCorrelations', u'featureName': u'team_position', u'correlation': 0.058723483}, {u'statisticType': u'featureCorrelations', u'featureName': u'team_id', u'correlation': 0.058723483}]}, {u'featureName': u'team_id', u'correlationValues': [{u'statisticType': u'featureCorrelations', u'featureName': u'team_budget', u'correlation': 0.058723483}, {u'statisticType': u'featureCorrelations', u'featureName': u'team_position', u'correlation': 1.0}, {u'statisticType': u'featureCorrelations', u'featureName': u'team_id', u'correlation': 1.0}]}]}, u'jobId': None, u'id': 2, u'features': [{u'type': u'double', u'name': u'team_budget', u'primary': True, u'description': u'-'}, {u'type': u'int', u'name': u'team_id', u'primary': False, u'description': u'-'}, {u'type': u'int', u'name': u'team_position', u'primary': False, u'description': u'-'}]}, {u'lastComputed': None, u'featuresHistogram': {u'featureDistributions': [{u'frequencyDistribution': [{u'bin': u'37.75', u'frequency': 3}, {u'bin': u'3.45', u'frequency': 2}, {u'bin': u'1.0', u'frequency': 3}, {u'bin': u'20.6', u'frequency': 3}, {u'bin': u'15.7', u'frequency': 3}, {u'bin': u'40.2', u'frequency': 2}, {u'bin': u'5.9', u'frequency': 3}, {u'bin': u'27.95', u'frequency': 3}, {u'bin': u'47.55', u'frequency': 3}, {u'bin': u'30.4', u'frequency': 2}, {u'bin': u'23.05', u'frequency': 2}, {u'bin': u'8.35', u'frequency': 2}, {u'bin': u'35.3', u'frequency': 2}, {u'bin': u'25.5', u'frequency': 2}, {u'bin': u'10.8', u'frequency': 3}, {u'bin': u'13.25', u'frequency': 2}, {u'bin': u'18.15', u'frequency': 2}, {u'bin': u'32.85', u'frequency': 3}, {u'bin': u'45.1', u'frequency': 2}, {u'bin': u'42.65', u'frequency': 3}], u'statisticType': u'featureDistributions', u'featureName': u'team_id'}, {u'frequencyDistribution': [{u'bin': u'37.75', u'frequency': 2}, {u'bin': u'77.6875', u'frequency': 1}, {u'bin': u'72.3625', u'frequency': 3}, {u'bin': u'64.375', u'frequency': 3}, {u'bin': u'43.075', u'frequency': 1}, {u'bin': u'53.725', u'frequency': 4}, {u'bin': u'61.7125', u'frequency': 4}, {u'bin': u'51.0625', u'frequency': 2}, {u'bin': u'40.4125', u'frequency': 3}, {u'bin': u'29.7625', u'frequency': 5}, {u'bin': u'35.0875', u'frequency': 2}, {u'bin': u'27.1', u'frequency': 5}, {u'bin': u'69.7', u'frequency': 1}, {u'bin': u'48.4', u'frequency': 1}, {u'bin': u'75.025', u'frequency': 1}, {u'bin': u'32.425', u'frequency': 2}, {u'bin': u'67.0375', u'frequency': 0}, {u'bin': u'45.7375', u'frequency': 2}, {u'bin': u'56.3875', u'frequency': 4}, {u'bin': u'59.05', u'frequency': 4}], u'statisticType': u'featureDistributions', u'featureName': u'average_position'}, {u'frequencyDistribution': [{u'bin': u'648.5', u'frequency': 2}, {u'bin': u'701.75', u'frequency': 2}, {u'bin': u'1553.75', u'frequency': 1}, {u'bin': u'914.75', u'frequency': 2}, {u'bin': u'1287.5', u'frequency': 3}, {u'bin': u'1021.25', u'frequency': 2}, {u'bin': u'808.25', u'frequency': 3}, {u'bin': u'1234.25', u'frequency': 4}, {u'bin': u'1394.0', u'frequency': 1}, {u'bin': u'542.0', u'frequency': 5}, {u'bin': u'1127.75', u'frequency': 4}, {u'bin': u'755.0', u'frequency': 2}, {u'bin': u'1340.75', u'frequency': 0}, {u'bin': u'1500.5', u'frequency': 1}, {u'bin': u'595.25', u'frequency': 5}, {u'bin': u'1181.0', u'frequency': 4}, {u'bin': u'968.0', u'frequency': 1}, {u'bin': u'861.5', u'frequency': 1}, {u'bin': u'1447.25', u'frequency': 3}, {u'bin': u'1074.5', u'frequency': 4}], u'statisticType': u'featureDistributions', u'featureName': u'sum_position'}]}, u'description': u'Features of average season scores for football teams', u'name': u'season_scores_features', u'created': u'2019-03-19T14:18:02Z', u'featurestoreId': 22, u'descriptiveStatistics': {u'descriptiveStats': [{u'metricValues': [{u'value': 50.0, u'metricName': u'count'}, {u'value': 50.489, u'metricName': u'mean'}, {u'value': 15.306195, u'metricName': u'stddev'}, {u'value': 27.1, u'metricName': u'min'}, {u'value': 80.35, u'metricName': u'max'}], u'statisticType': u'descriptiveStatistics', u'featureName': u'average_position'}, {u'metricValues': [{u'value': 50.0, u'metricName': u'count'}, {u'value': 25.5, u'metricName': u'mean'}, {u'value': 14.57738, u'metricName': u'stddev'}, {u'value': 1.0, u'metricName': u'min'}, {u'value': 50.0, u'metricName': u'max'}], u'statisticType': u'descriptiveStatistics', u'featureName': u'team_id'}, {u'metricValues': [{u'value': 50.0, u'metricName': u'count'}, {u'value': 1009.78, u'metricName': u'mean'}, {u'value': 306.1239, u'metricName': u'stddev'}, {u'value': 542.0, u'metricName': u'min'}, {u'value': 1607.0, u'metricName': u'max'}], u'statisticType': u'descriptiveStatistics', u'featureName': u'sum_position'}]}, u'creator': u'4f67e02d354864382be24f160c9dd50c03db1bcd@email.com', u'jobName': None, u'jobStatus': None, u'clusterAnalysis': {u'clusters': [{u'cluster': 3, u'datapointName': u'42'}, {u'cluster': 2, u'datapointName': u'48'}, {u'cluster': 3, u'datapointName': u'43'}, {u'cluster': 2, u'datapointName': u'49'}, {u'cluster': 0, u'datapointName': u'52'}, {u'cluster': 4, u'datapointName': u'24'}, {u'cluster': 4, u'datapointName': u'25'}, {u'cluster': 3, u'datapointName': u'26'}, {u'cluster': 2, u'datapointName': u'27'}, {u'cluster': 4, u'datapointName': u'20'}, {u'cluster': 4, u'datapointName': u'21'}, {u'cluster': 4, u'datapointName': u'22'}, {u'cluster': 4, u'datapointName': u'23'}, {u'cluster': 4, u'datapointName': u'46'}, {u'cluster': 2, u'datapointName': u'47'}, {u'cluster': 2, u'datapointName': u'44'}, {u'cluster': 1, u'datapointName': u'45'}, {u'cluster': 2, u'datapointName': u'28'}, {u'cluster': 2, u'datapointName': u'29'}, {u'cluster': 0, u'datapointName': u'40'}, {u'cluster': 3, u'datapointName': u'41'}, {u'cluster': 0, u'datapointName': u'1'}, {u'cluster': 2, u'datapointName': u'0'}, {u'cluster': 2, u'datapointName': u'3'}, {u'cluster': 0, u'datapointName': u'2'}, {u'cluster': 0, u'datapointName': u'5'}, {u'cluster': 0, u'datapointName': u'4'}, {u'cluster': 3, u'datapointName': u'7'}, {u'cluster': 0, u'datapointName': u'6'}, {u'cluster': 4, u'datapointName': u'9'}, {u'cluster': 4, u'datapointName': u'8'}, {u'cluster': 0, u'datapointName': u'51'}, {u'cluster': 4, u'datapointName': u'39'}, {u'cluster': 4, u'datapointName': u'38'}, {u'cluster': 3, u'datapointName': u'11'}, {u'cluster': 2, u'datapointName': u'10'}, {u'cluster': 2, u'datapointName': u'13'}, {u'cluster': 2, u'datapointName': u'12'}, {u'cluster': 2, u'datapointName': u'15'}, {u'cluster': 2, u'datapointName': u'14'}, {u'cluster': 2, u'datapointName': u'17'}, {u'cluster': 4, u'datapointName': u'16'}, {u'cluster': 4, u'datapointName': u'19'}, {u'cluster': 4, u'datapointName': u'18'}, {u'cluster': 1, u'datapointName': u'31'}, {u'cluster': 2, u'datapointName': u'30'}, {u'cluster': 1, u'datapointName': u'37'}, {u'cluster': 2, u'datapointName': u'36'}, {u'cluster': 4, u'datapointName': u'35'}, {u'cluster': 3, u'datapointName': u'34'}, {u'cluster': 0, u'datapointName': u'33'}, {u'cluster': 0, u'datapointName': u'32'}, {u'cluster': 3, u'datapointName': u'50'}], u'statisticType': u'clusterAnalysis', u'dataPoints': [{u'datapointName': u'42', u'firstDimension': -1129.6208, u'secondDimension': -23.361767}, {u'datapointName': u'48', u'firstDimension': -725.6221, u'secondDimension': -23.572412}, {u'datapointName': u'43', u'firstDimension': -1129.6208, u'secondDimension': -23.361767}, {u'datapointName': u'49', u'firstDimension': -725.6221, u'secondDimension': -23.572412}, {u'datapointName': u'52', u'firstDimension': -906.2184, u'secondDimension': -20.415012}, {u'datapointName': u'24', u'firstDimension': -1326.2179, u'secondDimension': -20.989096}, {u'datapointName': u'25', u'firstDimension': -1326.2179, u'secondDimension': -20.989096}, {u'datapointName': u'26', u'firstDimension': -1010.12537, u'secondDimension': -27.513346}, {u'datapointName': u'27', u'firstDimension': -639.667, u'secondDimension': -18.355698}, {u'datapointName': u'20', u'firstDimension': -1214.7228, u'secondDimension': -25.53304}, {u'datapointName': u'21', u'firstDimension': -1214.7228, u'secondDimension': -25.53304}, {u'datapointName': u'22', u'firstDimension': -1326.2179, u'secondDimension': -20.989096}, {u'datapointName': u'23', u'firstDimension': -1326.2179, u'secondDimension': -20.989096}, {u'datapointName': u'46', u'firstDimension': -1250.8225, u'secondDimension': -25.301079}, {u'datapointName': u'47', u'firstDimension': -725.6221, u'secondDimension': -23.572412}, {u'datapointName': u'44', u'firstDimension': -542.1236, u'secondDimension': -24.585075}, {u'datapointName': u'45', u'firstDimension': -1475.3229, u'secondDimension': -26.29928}, {u'datapointName': u'28', u'firstDimension': -639.667, u'secondDimension': -18.355698}, {u'datapointName': u'29', u'firstDimension': -577.17426, u'secondDimension': -25.30287}, {u'datapointName': u'40', u'firstDimension': -937.07294, u'secondDimension': -24.931822}, {u'datapointName': u'41', u'firstDimension': -1129.6208, u'secondDimension': -23.361767}, {u'datapointName': u'1', u'firstDimension': -806.87085, u'secondDimension': -22.551102}, {u'datapointName': u'0', u'firstDimension': -687.4733, u'secondDimension': -24.70508}, {u'datapointName': u'3', u'firstDimension': -563.3205, u'secondDimension': -21.619833}, {u'datapointName': u'2', u'firstDimension': -806.87085, u'secondDimension': -22.551102}, {u'datapointName': u'5', u'firstDimension': -822.0185, u'secondDimension': -20.290386}, {u'datapointName': u'4', u'firstDimension': -841.8235, u'secondDimension': -25.266495}, {u'datapointName': u'7', u'firstDimension': -1101.1786, u'secondDimension': -30.97769}, {u'datapointName': u'6', u'firstDimension': -822.0185, u'secondDimension': -20.290386}, {u'datapointName': u'9', u'firstDimension': -1233.9686, u'secondDimension': -21.470905}, {u'datapointName': u'8', u'firstDimension': -1233.9686, u'secondDimension': -21.470905}, {u'datapointName': u'51', u'firstDimension': -906.2184, u'secondDimension': -20.415012}, {u'datapointName': u'39', u'firstDimension': -1212.9187, u'secondDimension': -21.439749}, {u'datapointName': u'38', u'firstDimension': -1212.9187, u'secondDimension': -21.439749}, {u'datapointName': u'11', u'firstDimension': -1073.4222, u'secondDimension': -24.610416}, {u'datapointName': u'10', u'firstDimension': -660.766, u'secondDimension': -17.388054}, {u'datapointName': u'13', u'firstDimension': -581.0764, u'secondDimension': -27.49665}, {u'datapointName': u'12', u'firstDimension': -581.0764, u'secondDimension': -27.49665}, {u'datapointName': u'15', u'firstDimension': -596.2731, u'secondDimension': -24.237135}, {u'datapointName': u'14', u'firstDimension': -581.0764, u'secondDimension': -27.49665}, {u'datapointName': u'17', u'firstDimension': -630.42163, u'secondDimension': -22.908285}, {u'datapointName': u'16', u'firstDimension': -1248.1162, u'secondDimension': -19.161144}, {u'datapointName': u'19', u'firstDimension': -1214.7228, u'secondDimension': -25.53304}, {u'datapointName': u'18', u'firstDimension': -1189.5747, u'secondDimension': -27.303299}, {u'datapointName': u'31', u'firstDimension': -1523.4231, u'secondDimension': -26.655867}, {u'datapointName': u'30', u'firstDimension': -577.17426, u'secondDimension': -25.30287}, {u'datapointName': u'37', u'firstDimension': -1441.5172, u'secondDimension': -20.636534}, {u'datapointName': u'36', u'firstDimension': -542.22156, u'secondDimension': -22.587477}, {u'datapointName': u'35', u'firstDimension': -1237.7728, u'secondDimension': -25.662287}, {u'datapointName': u'34', u'firstDimension': -1170.8677, u'secondDimension': -20.378637}, {u'datapointName': u'33', u'firstDimension': -962.9762, u'secondDimension': -28.204605}, {u'datapointName': u'32', u'firstDimension': -962.9762, u'secondDimension': -28.204605}, {u'datapointName': u'50', u'firstDimension': -1061.2747, u'secondDimension': -27.018269}]}, u'inodeId': 106583, u'featurestoreName': u'project_bde67d4d2ef6dcfc_featurestore', u'hdfsStorePaths': [u'hdfs://10.0.2.15:8020/apps/hive/warehouse/project_bde67d4d2ef6dcfc_featurestore.db/season_scores_features_1'], u'dependencies': [], u'version': 1, u'featureCorrelationMatrix': {u'featureCorrelations': [{u'featureName': u'sum_position', u'correlationValues': [{u'statisticType': u'featureCorrelations', u'featureName': u'average_position', u'correlation': 1.0}, {u'statisticType': u'featureCorrelations', u'featureName': u'team_id', u'correlation': 0.97596633}, {u'statisticType': u'featureCorrelations', u'featureName': u'sum_position', u'correlation': 1.0}]}, {u'featureName': u'team_id', u'correlationValues': [{u'statisticType': u'featureCorrelations', u'featureName': u'average_position', u'correlation': 0.97596633}, {u'statisticType': u'featureCorrelations', u'featureName': u'team_id', u'correlation': 1.0}, {u'statisticType': u'featureCorrelations', u'featureName': u'sum_position', u'correlation': 0.97596633}]}, {u'featureName': u'average_position', u'correlationValues': [{u'statisticType': u'featureCorrelations', u'featureName': u'average_position', u'correlation': 1.0}, {u'statisticType': u'featureCorrelations', u'featureName': u'team_id', u'correlation': 0.97596633}, {u'statisticType': u'featureCorrelations', u'featureName': u'sum_position', u'correlation': 1.0}]}]}, u'jobId': None, u'id': 3, u'features': [{u'type': u'double', u'name': u'average_position', u'primary': False, u'description': u'-'}, {u'type': u'double', u'name': u'sum_position', u'primary': False, u'description': u'-'}, {u'type': u'int', u'name': u'team_id', u'primary': True, u'description': u'-'}]}, {u'lastComputed': None, u'featuresHistogram': {u'featureDistributions': [{u'frequencyDistribution': [{u'bin': u'37.75', u'frequency': 3}, {u'bin': u'3.45', u'frequency': 2}, {u'bin': u'1.0', u'frequency': 3}, {u'bin': u'20.6', u'frequency': 3}, {u'bin': u'15.7', u'frequency': 3}, {u'bin': u'40.2', u'frequency': 2}, {u'bin': u'5.9', u'frequency': 3}, {u'bin': u'27.95', u'frequency': 3}, {u'bin': u'47.55', u'frequency': 3}, {u'bin': u'30.4', u'frequency': 2}, {u'bin': u'23.05', u'frequency': 2}, {u'bin': u'8.35', u'frequency': 2}, {u'bin': u'35.3', u'frequency': 2}, {u'bin': u'25.5', u'frequency': 2}, {u'bin': u'10.8', u'frequency': 3}, {u'bin': u'13.25', u'frequency': 2}, {u'bin': u'18.15', u'frequency': 2}, {u'bin': u'32.85', u'frequency': 3}, {u'bin': u'45.1', u'frequency': 2}, {u'bin': u'42.65', u'frequency': 3}], u'statisticType': u'featureDistributions', u'featureName': u'team_id'}, {u'frequencyDistribution': [{u'bin': u'23854.164275', u'frequency': 1}, {u'bin': u'42106.676735', u'frequency': 0}, {u'bin': u'37543.54862', u'frequency': 0}, {u'bin': u'32980.420505', u'frequency': 1}, {u'bin': u'69485.445425', u'frequency': 0}, {u'bin': u'19291.03616', u'frequency': 2}, {u'bin': u'1038.5237', u'frequency': 32}, {u'bin': u'46669.80485', u'frequency': 0}, {u'bin': u'10164.77993', u'frequency': 2}, {u'bin': u'14727.908045', u'frequency': 0}, {u'bin': u'55796.06108', u'frequency': 0}, {u'bin': u'60359.189195', u'frequency': 0}, {u'bin': u'74048.57354', u'frequency': 0}, {u'bin': u'83174.82977', u'frequency': 0}, {u'bin': u'87737.957885', u'frequency': 1}, {u'bin': u'64922.31731', u'frequency': 0}, {u'bin': u'51232.932965', u'frequency': 0}, {u'bin': u'28417.29239', u'frequency': 1}, {u'bin': u'78611.701655', u'frequency': 0}, {u'bin': u'5601.651815', u'frequency': 10}], u'statisticType': u'featureDistributions', u'featureName': u'average_attendance'}, {u'frequencyDistribution': [{u'bin': u'568345.8724999999', u'frequency': 1}, {u'bin': u'112033.04125', u'frequency': 10}, {u'bin': u'1389708.9687500002', u'frequency': 0}, {u'bin': u'659608.43875', u'frequency': 1}, {u'bin': u'842133.57125', u'frequency': 0}, {u'bin': u'933396.1375000001', u'frequency': 0}, {u'bin': u'203295.6075', u'frequency': 2}, {u'bin': u'385820.74', u'frequency': 2}, {u'bin': u'477083.30625', u'frequency': 1}, {u'bin': u'750871.005', u'frequency': 0}, {u'bin': u'1207183.8362500002', u'frequency': 0}, {u'bin': u'20770.475', u'frequency': 32}, {u'bin': u'1480971.5350000001', u'frequency': 0}, {u'bin': u'1298446.4025000001', u'frequency': 0}, {u'bin': u'1024658.70375', u'frequency': 0}, {u'bin': u'1572234.1012500001', u'frequency': 0}, {u'bin': u'1115921.27', u'frequency': 0}, {u'bin': u'294558.17375', u'frequency': 0}, {u'bin': u'1754759.2337500001', u'frequency': 1}, {u'bin': u'1663496.6675000002', u'frequency': 0}], u'statisticType': u'featureDistributions', u'featureName': u'sum_attendance'}]}, u'description': u'Features of average attendance of games of football teams', u'name': u'attendances_features', u'created': u'2019-03-19T14:18:20Z', u'featurestoreId': 22, u'descriptiveStatistics': {u'descriptiveStats': [{u'metricValues': [{u'value': 50.0, u'metricName': u'count'}, {u'value': 25.5, u'metricName': u'mean'}, {u'value': 14.57738, u'metricName': u'stddev'}, {u'value': 1.0, u'metricName': u'min'}, {u'value': 50.0, u'metricName': u'max'}], u'statisticType': u'descriptiveStatistics', u'featureName': u'team_id'}, {u'metricValues': [{u'value': 50.0, u'metricName': u'count'}, {u'value': 8669.394, u'metricName': u'mean'}, {u'value': 14232.309, u'metricName': u'stddev'}, {u'value': 1038.5237, u'metricName': u'min'}, {u'value': 92301.086, u'metricName': u'max'}], u'statisticType': u'descriptiveStatistics', u'featureName': u'average_attendance'}, {u'metricValues': [{u'value': 50.0, u'metricName': u'count'}, {u'value': 173387.88, u'metricName': u'mean'}, {u'value': 284646.2, u'metricName': u'stddev'}, {u'value': 20770.475, u'metricName': u'min'}, {u'value': 1846021.8, u'metricName': u'max'}], u'statisticType': u'descriptiveStatistics', u'featureName': u'sum_attendance'}]}, u'creator': u'4f67e02d354864382be24f160c9dd50c03db1bcd@email.com', u'jobName': None, u'jobStatus': None, u'clusterAnalysis': {u'clusters': [{u'cluster': 0, u'datapointName': u'42'}, {u'cluster': 0, u'datapointName': u'43'}, {u'cluster': 1, u'datapointName': u'24'}, {u'cluster': 4, u'datapointName': u'25'}, {u'cluster': 0, u'datapointName': u'26'}, {u'cluster': 0, u'datapointName': u'27'}, {u'cluster': 4, u'datapointName': u'20'}, {u'cluster': 0, u'datapointName': u'21'}, {u'cluster': 1, u'datapointName': u'22'}, {u'cluster': 1, u'datapointName': u'23'}, {u'cluster': 4, u'datapointName': u'46'}, {u'cluster': 0, u'datapointName': u'47'}, {u'cluster': 0, u'datapointName': u'44'}, {u'cluster': 0, u'datapointName': u'45'}, {u'cluster': 0, u'datapointName': u'28'}, {u'cluster': 0, u'datapointName': u'29'}, {u'cluster': 0, u'datapointName': u'40'}, {u'cluster': 0, u'datapointName': u'41'}, {u'cluster': 3, u'datapointName': u'1'}, {u'cluster': 0, u'datapointName': u'0'}, {u'cluster': 4, u'datapointName': u'3'}, {u'cluster': 4, u'datapointName': u'2'}, {u'cluster': 0, u'datapointName': u'5'}, {u'cluster': 4, u'datapointName': u'4'}, {u'cluster': 0, u'datapointName': u'7'}, {u'cluster': 0, u'datapointName': u'6'}, {u'cluster': 0, u'datapointName': u'9'}, {u'cluster': 4, u'datapointName': u'8'}, {u'cluster': 0, u'datapointName': u'39'}, {u'cluster': 0, u'datapointName': u'38'}, {u'cluster': 4, u'datapointName': u'11'}, {u'cluster': 0, u'datapointName': u'10'}, {u'cluster': 0, u'datapointName': u'13'}, {u'cluster': 4, u'datapointName': u'12'}, {u'cluster': 0, u'datapointName': u'15'}, {u'cluster': 0, u'datapointName': u'14'}, {u'cluster': 0, u'datapointName': u'17'}, {u'cluster': 0, u'datapointName': u'16'}, {u'cluster': 4, u'datapointName': u'19'}, {u'cluster': 0, u'datapointName': u'18'}, {u'cluster': 4, u'datapointName': u'31'}, {u'cluster': 0, u'datapointName': u'30'}, {u'cluster': 0, u'datapointName': u'37'}, {u'cluster': 0, u'datapointName': u'36'}, {u'cluster': 0, u'datapointName': u'35'}, {u'cluster': 4, u'datapointName': u'34'}, {u'cluster': 4, u'datapointName': u'33'}, {u'cluster': 4, u'datapointName': u'32'}], u'statisticType': u'clusterAnalysis', u'dataPoints': [{u'datapointName': u'42', u'firstDimension': 102771.18, u'secondDimension': -30.879086}, {u'datapointName': u'43', u'firstDimension': 102771.18, u'secondDimension': -30.879086}, {u'datapointName': u'24', u'firstDimension': 1848327.9, u'secondDimension': -34.79515}, {u'datapointName': u'25', u'firstDimension': 148782.75, u'secondDimension': -15.72037}, {u'datapointName': u'26', u'firstDimension': 36851.344, u'secondDimension': -48.673798}, {u'datapointName': u'27', u'firstDimension': 41034.33, u'secondDimension': -41.75028}, {u'datapointName': u'20', u'firstDimension': 186493.77, u'secondDimension': -15.409884}, {u'datapointName': u'21', u'firstDimension': 39961.24, u'secondDimension': -47.73066}, {u'datapointName': u'22', u'firstDimension': 1848327.9, u'secondDimension': -34.79515}, {u'datapointName': u'23', u'firstDimension': 1848327.9, u'secondDimension': -34.79515}, {u'datapointName': u'46', u'firstDimension': 141950.81, u'secondDimension': -16.595453}, {u'datapointName': u'47', u'firstDimension': 35798.867, u'secondDimension': -42.654552}, {u'datapointName': u'44', u'firstDimension': 102771.18, u'secondDimension': -30.879086}, {u'datapointName': u'45', u'firstDimension': 59751.45, u'secondDimension': -33.092506}, {u'datapointName': u'28', u'firstDimension': 41034.33, u'secondDimension': -41.75028}, {u'datapointName': u'29', u'firstDimension': 41034.33, u'secondDimension': -41.75028}, {u'datapointName': u'40', u'firstDimension': 102771.18, u'secondDimension': -30.879086}, {u'datapointName': u'41', u'firstDimension': 102771.18, u'secondDimension': -30.879086}, {u'datapointName': u'1', u'firstDimension': 392409.06, u'secondDimension': -13.174876}, {u'datapointName': u'0', u'firstDimension': 81597.9, u'secondDimension': -28.491951}, {u'datapointName': u'3', u'firstDimension': 144714.0, u'secondDimension': -22.645977}, {u'datapointName': u'2', u'firstDimension': 129410.7, u'secondDimension': -18.366167}, {u'datapointName': u'5', u'firstDimension': 63876.605, u'secondDimension': -41.16793}, {u'datapointName': u'4', u'firstDimension': 144714.0, u'secondDimension': -22.645977}, {u'datapointName': u'7', u'firstDimension': 63876.605, u'secondDimension': -41.16793}, {u'datapointName': u'6', u'firstDimension': 63876.605, u'secondDimension': -41.16793}, {u'datapointName': u'9', u'firstDimension': 56550.477, u'secondDimension': -44.033978}, {u'datapointName': u'8', u'firstDimension': 141697.38, u'secondDimension': -17.59082}, {u'datapointName': u'39', u'firstDimension': 89404.17, u'secondDimension': -25.634682}, {u'datapointName': u'38', u'firstDimension': 89404.17, u'secondDimension': -25.634682}, {u'datapointName': u'11', u'firstDimension': 188339.25, u'secondDimension': -12.443628}, {u'datapointName': u'10', u'firstDimension': 56550.477, u'secondDimension': -44.033978}, {u'datapointName': u'13', u'firstDimension': 99416.984, u'secondDimension': -24.817757}, {u'datapointName': u'12', u'firstDimension': 188339.25, u'secondDimension': -12.443628}, {u'datapointName': u'15', u'firstDimension': 61970.82, u'secondDimension': -34.133087}, {u'datapointName': u'14', u'firstDimension': 99416.984, u'secondDimension': -24.817757}, {u'datapointName': u'17', u'firstDimension': 68041.02, u'secondDimension': -29.244074}, {u'datapointName': u'16', u'firstDimension': 104956.94, u'secondDimension': -22.91905}, {u'datapointName': u'19', u'firstDimension': 186493.77, u'secondDimension': -15.409884}, {u'datapointName': u'18', u'firstDimension': 68041.02, u'secondDimension': -29.244074}, {u'datapointName': u'31', u'firstDimension': 187690.45, u'secondDimension': -11.431766}, {u'datapointName': u'30', u'firstDimension': 41034.33, u'secondDimension': -41.75028}, {u'datapointName': u'37', u'firstDimension': 89404.17, u'secondDimension': -25.634682}, {u'datapointName': u'36', u'firstDimension': 71798.7, u'secondDimension': -26.31278}, {u'datapointName': u'35', u'firstDimension': 41967.984, u'secondDimension': -45.76735}, {u'datapointName': u'34', u'firstDimension': 179835.23, u'secondDimension': -13.288139}, {u'datapointName': u'33', u'firstDimension': 282588.78, u'secondDimension': -12.166903}, {u'datapointName': u'32', u'firstDimension': 282588.78, u'secondDimension': -12.166903}]}, u'inodeId': 106596, u'featurestoreName': u'project_bde67d4d2ef6dcfc_featurestore', u'hdfsStorePaths': [u'hdfs://10.0.2.15:8020/apps/hive/warehouse/project_bde67d4d2ef6dcfc_featurestore.db/attendances_features_1'], u'dependencies': [], u'version': 1, u'featureCorrelationMatrix': {u'featureCorrelations': [{u'featureName': u'sum_attendance', u'correlationValues': [{u'statisticType': u'featureCorrelations', u'featureName': u'team_id', u'correlation': -0.5932929}, {u'statisticType': u'featureCorrelations', u'featureName': u'average_attendance', u'correlation': 1.0}, {u'statisticType': u'featureCorrelations', u'featureName': u'sum_attendance', u'correlation': 1.0}]}, {u'featureName': u'average_attendance', u'correlationValues': [{u'statisticType': u'featureCorrelations', u'featureName': u'team_id', u'correlation': -0.5932929}, {u'statisticType': u'featureCorrelations', u'featureName': u'average_attendance', u'correlation': 1.0}, {u'statisticType': u'featureCorrelations', u'featureName': u'sum_attendance', u'correlation': 1.0}]}, {u'featureName': u'team_id', u'correlationValues': [{u'statisticType': u'featureCorrelations', u'featureName': u'team_id', u'correlation': 1.0}, {u'statisticType': u'featureCorrelations', u'featureName': u'average_attendance', u'correlation': -0.5932929}, {u'statisticType': u'featureCorrelations', u'featureName': u'sum_attendance', u'correlation': -0.5932929}]}]}, u'jobId': None, u'id': 4, u'features': [{u'type': u'double', u'name': u'average_attendance', u'primary': False, u'description': u'-'}, {u'type': u'double', u'name': u'sum_attendance', u'primary': False, u'description': u'-'}, {u'type': u'int', u'name': u'team_id', u'primary': True, u'description': u'-'}]}, {u'lastComputed': None, u'featuresHistogram': None, u'description': u'a spanish version of teams_features', u'name': u'teams_features_spanish', u'created': u'2019-03-19T14:18:41Z', u'featurestoreId': 22, u'descriptiveStatistics': None, u'creator': u'4f67e02d354864382be24f160c9dd50c03db1bcd@email.com', u'jobName': None, u'jobStatus': None, u'clusterAnalysis': None, u'inodeId': 106624, u'featurestoreName': u'project_bde67d4d2ef6dcfc_featurestore', u'hdfsStorePaths': [u'hdfs://10.0.2.15:8020/apps/hive/warehouse/project_bde67d4d2ef6dcfc_featurestore.db/teams_features_spanish_1'], u'dependencies': [], u'version': 1, u'featureCorrelationMatrix': None, u'jobId': None, u'id': 6, u'features': [{u'type': u'int', u'name': u'equipo_id', u'primary': False, u'description': u'-'}, {u'type': u'int', u'name': u'equipo_posicion', u'primary': False, u'description': u'-'}, {u'type': u'double', u'name': u'equipo_presupuesto', u'primary': True, u'description': u'-'}]}, {u'lastComputed': None, u'featuresHistogram': None, u'description': u'a spanish version of teams_features', u'name': u'teams_features_spanish', u'created': u'2019-03-19T14:18:51Z', u'featurestoreId': 22, u'descriptiveStatistics': None, u'creator': u'4f67e02d354864382be24f160c9dd50c03db1bcd@email.com', u'jobName': None, u'jobStatus': None, u'clusterAnalysis': None, u'inodeId': 106637, u'featurestoreName': u'project_bde67d4d2ef6dcfc_featurestore', u'hdfsStorePaths': [u'hdfs://10.0.2.15:8020/apps/hive/warehouse/project_bde67d4d2ef6dcfc_featurestore.db/teams_features_spanish_2'], u'dependencies': [], u'version': 2, u'featureCorrelationMatrix': None, u'jobId': None, u'id': 7, u'features': [{u'type': u'int', u'name': u'equipo_id', u'primary': False, u'description': u'-'}, {u'type': u'int', u'name': u'equipo_posicion', u'primary': False, u'description': u'-'}, {u'type': u'double', u'name': u'equipo_presupuesto', u'primary': True, u'description': u'-'}]}]}"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.get_featurestore_metadata(update_cache=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1106,7 +940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1115,7 +949,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1124,7 +958,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1133,7 +967,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1142,7 +976,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1151,7 +985,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1171,18 +1005,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT team_budget FROM teams_features_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tmp = featurestore.get_feature(\"team_budget\")\n",
     "assert tmp.count() == 50\n",
@@ -1192,18 +1017,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT team_budget FROM teams_features_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tmp = featurestore.get_feature(\n",
     "    \"team_budget\", \n",
@@ -1219,18 +1035,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM teams_features_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tmp = featurestore.get_featuregroup(\"teams_features\")\n",
     "assert tmp.count() == 50\n",
@@ -1242,18 +1049,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM teams_features_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tmp = featurestore.get_featuregroup(\n",
     "    \"teams_features\", \n",
@@ -1270,18 +1068,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT team_budget, average_attendance FROM teams_features_1 JOIN attendances_features_1 ON teams_features_1.`team_id`=attendances_features_1.`team_id`"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "features = [\"team_budget\", \"average_attendance\"]\n",
     "tmp = featurestore.get_features(\n",
@@ -1294,18 +1083,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT teams_features_1.team_budget, attendances_features_1.average_attendance FROM teams_features_1 JOIN attendances_features_1 ON teams_features_1.`team_id`=attendances_features_1.`team_id`"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "features = [\"teams_features_1.team_budget\", \"attendances_features_1.average_attendance\"]\n",
     "tmp = featurestore.get_features(features)\n",
@@ -1316,18 +1096,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT team_budget, average_attendance FROM teams_features_1 JOIN attendances_features_1 ON teams_features_1.`team_id`=attendances_features_1.`team_id`"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "features = [\"team_budget\", \"average_attendance\"]\n",
     "tmp = featurestore.get_features(\n",
@@ -1345,18 +1116,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT team_budget, average_attendance FROM teams_features_1 JOIN attendances_features_1 ON teams_features_1.`team_id`=attendances_features_1.`team_id`"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tmp = featurestore.get_features(\n",
     "    features,\n",
@@ -1375,18 +1137,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT team_budget, average_attendance, team_position, sum_attendance FROM teams_features_1 JOIN attendances_features_1 ON teams_features_1.`team_id`=attendances_features_1.`team_id`"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "features = [\"team_budget\", \"average_attendance\",\n",
     "    \"team_position\", \"sum_attendance\"\n",
@@ -1401,18 +1154,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT team_budget, team_id FROM teams_features_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "features = [\"team_budget\", \"team_id\"]\n",
     "tmp = featurestore.get_features(\n",
@@ -1428,18 +1172,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT team_budget, score FROM teams_features_1 JOIN games_features_1 ON games_features_1.home_team_id = teams_features_1.team_id"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tmp = featurestore.sql(\n",
     "    \"SELECT team_budget, score \" \\\n",
@@ -1453,18 +1188,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM teams_features_1 WHERE team_position < 5"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tmp = featurestore.sql(\"SELECT * FROM teams_features_1 WHERE team_position < 5\")\n",
     "assert len(tmp.columns) == 3\n",
@@ -1477,18 +1203,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM teams_features_1 WHERE team_position < 5"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tmp = featurestore.sql(\"SELECT * FROM teams_features_1 WHERE team_position < 5\",\n",
     "                featurestore=featurestore.project_featurestore(), \n",
@@ -1510,7 +1227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1526,18 +1243,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM teams_features_spanish_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "spanish_team_features_df = featurestore.get_featuregroup(\n",
     "    \"teams_features_spanish\")\n",
@@ -1547,19 +1255,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM teams_features_spanish_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.insert_into_featuregroup(\n",
     "    sample_df, \n",
@@ -1578,19 +1276,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM teams_features_spanish_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.insert_into_featuregroup(\n",
     "    sample_df, \n",
@@ -1614,19 +1302,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM teams_features_spanish_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.insert_into_featuregroup(\n",
     "    sample_df, \n",
@@ -1650,18 +1328,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT team_budget, average_attendance FROM teams_features_1 JOIN attendances_features_1 ON teams_features_1.`team_id`=attendances_features_1.`team_id`"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pandas_df = featurestore.get_features([\"team_budget\", \"average_attendance\"], dataframe_type=\"pandas\")\n",
     "assert \"team_budget\" in pandas_df.columns.values\n",
@@ -1673,18 +1342,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT team_budget, average_attendance FROM teams_features_1 JOIN attendances_features_1 ON teams_features_1.`team_id`=attendances_features_1.`team_id`"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "numpy_df = featurestore.get_features([\"team_budget\", \"average_attendance\"], \n",
     "                                      dataframe_type=\"numpy\")\n",
@@ -1695,18 +1355,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT team_budget, average_attendance FROM teams_features_1 JOIN attendances_features_1 ON teams_features_1.`team_id`=attendances_features_1.`team_id`"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "python_df = featurestore.get_features([\"team_budget\", \"average_attendance\"], \n",
     "                                      dataframe_type=\"python\")\n",
@@ -1716,18 +1367,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT team_budget, average_attendance FROM teams_features_1 JOIN attendances_features_1 ON teams_features_1.`team_id`=attendances_features_1.`team_id`"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "spark_df = featurestore.get_features([\"team_budget\", \"average_attendance\"], \n",
     "                                      dataframe_type=\"spark\")\n",
@@ -1737,18 +1379,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Feature group created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Let's rename the columns to differentiate this feature group from existing ones in the feature store\n",
     "pandas_df.columns = [\"team_budget_test\", \"average_attendance_test\"]\n",
@@ -1767,21 +1400,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM pandas_test_example_1\n",
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM pandas_test_example_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "count_pre_pandas_insert_overwrite = featurestore.get_featuregroup(\"pandas_test_example\").count()\n",
     "featurestore.insert_into_featuregroup(\n",
@@ -1798,18 +1419,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Feature group created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_featuregroup(\n",
     "    numpy_df,\n",
@@ -1825,21 +1437,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM numpy_test_example_1\n",
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM numpy_test_example_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "numpy_test_df_count_pre_insert_overwrite = featurestore.get_featuregroup(\"numpy_test_example\", dataframe_type=\"spark\").count()\n",
     "featurestore.insert_into_featuregroup(\n",
@@ -1856,20 +1456,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Feature group created successfully\n",
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM python_test_example_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_featuregroup(\n",
     "    python_df,\n",
@@ -1887,19 +1476,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM python_test_example_1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.insert_into_featuregroup(\n",
     "    python_df, \n",
@@ -1923,44 +1502,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM teams_features_1\n",
-      "computing descriptive statistics for : teams_features\n",
-      "computing feature correlation for: teams_features\n",
-      "computing feature histograms for: teams_features\n",
-      "computing cluster analysis for: teams_features"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.update_featuregroup_stats(\"teams_features\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT * FROM teams_features_1\n",
-      "computing descriptive statistics for : teams_features\n",
-      "computing feature correlation for: teams_features\n",
-      "computing feature histograms for: teams_features\n",
-      "computing cluster analysis for: teams_features"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.update_featuregroup_stats(\n",
     "    \"teams_features\", \n",
@@ -1985,18 +1538,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running sql: use project_bde67d4d2ef6dcfc_featurestore\n",
-      "Running sql: SELECT team_budget, average_attendance, team_position FROM teams_features_1 JOIN attendances_features_1 ON teams_features_1.`team_id`=attendances_features_1.`team_id`"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "features_df = featurestore.get_features(\n",
     "    [\"team_budget\", \"average_attendance\",\n",
@@ -2007,17 +1551,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Training Dataset created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_training_dataset(\n",
     "    features_df, \"team_position_prediction\",\n",
@@ -2031,17 +1567,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Training Dataset created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_training_dataset(\n",
     "    features_df, \"team_position_prediction_csv\",\n",
@@ -2060,17 +1588,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Training Dataset created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_training_dataset(\n",
     "    features_df, \"team_position_prediction_tsv\",\n",
@@ -2089,17 +1609,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Training Dataset created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_training_dataset(\n",
     "    features_df, \"team_position_prediction_parquet\",\n",
@@ -2118,17 +1630,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Training Dataset created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_training_dataset(\n",
     "    features_df, \"team_position_prediction_orc\",\n",
@@ -2147,17 +1651,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Training Dataset created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_training_dataset(\n",
     "    features_df, \"team_position_prediction_avro\",\n",
@@ -2176,17 +1672,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Training Dataset created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_training_dataset(\n",
     "    features_df, \"team_position_prediction_hdf5\",\n",
@@ -2205,17 +1693,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Training Dataset created successfully"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.create_training_dataset(\n",
     "    features_df, \"team_position_prediction_npy\",\n",
@@ -2234,17 +1714,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Petastorm is only supported in python 3"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Petastorm is only supported in python 3\n",
     "if sys.version_info[0] >= 3:\n",
@@ -2277,7 +1749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2303,7 +1775,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2333,7 +1805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2342,7 +1814,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2351,7 +1823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2360,7 +1832,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2372,7 +1844,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2394,40 +1866,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "computing descriptive statistics for : team_position_prediction\n",
-      "computing feature correlation for: team_position_prediction\n",
-      "computing feature histograms for: team_position_prediction\n",
-      "computing cluster analysis for: team_position_prediction"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.update_training_dataset_stats(\"team_position_prediction\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "computing descriptive statistics for : team_position_prediction\n",
-      "computing feature correlation for: team_position_prediction\n",
-      "computing feature histograms for: team_position_prediction\n",
-      "computing cluster analysis for: team_position_prediction"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "featurestore.update_training_dataset_stats(\n",
     "    \"team_position_prediction\", \n",
@@ -2449,7 +1899,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2461,7 +1911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2471,7 +1921,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2483,7 +1933,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2494,7 +1944,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2505,7 +1955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2516,7 +1966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2526,7 +1976,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2544,25 +1994,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DataFrame[]\n",
-      "DataFrame[]\n",
-      "DataFrame[]\n",
-      "DataFrame[]\n",
-      "DataFrame[]\n",
-      "DataFrame[]\n",
-      "DataFrame[]\n",
-      "DataFrame[]\n",
-      "DataFrame[]"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Delete feature groups\n",
     "spark.sql('use ' + featurestore.project_featurestore())\n",
@@ -2572,7 +2006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2584,7 +2018,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2613,7 +2047,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2627,7 +2061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2659,7 +2093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
    - Attach a python module to their notebook from hdfs with an API call.

  Example usage:

  from hops import hdfs
  hdfs.add_py_file("Resources/module.py")
  import module
  module.function()

    - Tests for adding python module

    - Fix hdfs.isfile using wrong module

    - Add hdfs.isdir function

    - Tests for copy_to_local with various edge-cases

    - Improve tests for copy_to_hdfs

    - Bugfix for copy_to_local where it would not download a file that changed on HDFS

    - Bugfix for copy_to_local local target directory to work with absolute paths