### PR TITLE
[HOPSWORKS-1377][featurestore][queryplanner] Feature group composite key support

### DIFF
--- a/hops/featurestore.py
+++ b/hops/featurestore.py
@@ -586,7 +586,7 @@ def create_on_demand_featuregroup(sql_query, featuregroup, jdbc_connector_name, 
     fs_utils._log("Feature group created successfully")
 
 
-def create_featuregroup(df, featuregroup, primary_key=None, description="", featurestore=None,
+def create_featuregroup(df, featuregroup, primary_keys=[], description="", featurestore=None,
                         featuregroup_version=1, jobs=[],
                         descriptive_statistics=True, feature_correlation=True,
                         feature_histograms=True, cluster_analysis=True, stat_columns=None, num_bins=20,
@@ -614,8 +614,8 @@ def create_featuregroup(df, featuregroup, primary_key=None, description="", feat
     Args:
         :df: the dataframe to create the featuregroup for (used to infer the schema)
         :featuregroup: the name of the new featuregroup
-        :primary_key: the primary key of the new featuregroup, if not specified, the first column in the dataframe will
-                      be used as primary
+        :primary_keys: a list of primary keys of the new featuregroup, if not specified,
+                       the first column in the dataframe will be used as primary
         :description: a description of the featuregroup
         :featurestore: the featurestore of the featuregroup (defaults to the project's featurestore)
         :featuregroup_version: the version of the featuregroup (defaults to 1)
@@ -647,7 +647,7 @@ def create_featuregroup(df, featuregroup, primary_key=None, description="", feat
     # Try with the cache first
     try:
         core._do_create_featuregroup(df, core._get_featurestore_metadata(featurestore, update_cache=False),
-                                     featuregroup, primary_key=primary_key, description= description,
+                                     featuregroup, primary_keys=primary_keys, description= description,
                                      featurestore=featurestore, featuregroup_version=featuregroup_version,
                                      jobs=jobs, descriptive_statistics=descriptive_statistics,
                                      feature_correlation=feature_correlation, feature_histograms=feature_histograms,
@@ -657,7 +657,7 @@ def create_featuregroup(df, featuregroup, primary_key=None, description="", feat
     # If it fails, update cache and retry
     except:
         core._do_create_featuregroup(df, core._get_featurestore_metadata(featurestore, update_cache=True),
-                                     featuregroup, primary_key=primary_key, description= description,
+                                     featuregroup, primary_keys=primary_keys, description= description,
                                      featurestore=featurestore, featuregroup_version=featuregroup_version,
                                      jobs=jobs, descriptive_statistics=descriptive_statistics,
                                      feature_correlation=feature_correlation, feature_histograms=feature_histograms,
@@ -1972,7 +1972,7 @@ def sync_hive_table_with_featurestore(featuregroup, description="", featurestore
     fs_utils._log("Hive Table: {} was successfully synchronized with Feature Store: {}".format(featuregroup,
                                                                                                featurestore))
 
-def import_featuregroup_redshift(storage_connector, query, featuregroup, primary_key=None, description="",
+def import_featuregroup_redshift(storage_connector, query, featuregroup, primary_keys=[], description="",
                                  featurestore=None, featuregroup_version=1, jobs=[], descriptive_statistics=True,
                                  feature_correlation=True, feature_histograms=True, cluster_analysis=True,
                                  stat_columns=None, num_bins=20, corr_method='pearson', num_clusters=5,
@@ -1986,7 +1986,8 @@ def import_featuregroup_redshift(storage_connector, query, featuregroup, primary
 
     >>> featurestore.import_featuregroup_redshift(my_jdbc_connector_name, sql_query, featuregroup_name)
     >>> # You can also be explicitly specify featuregroup metadata and what statistics to compute:
-    >>> featurestore.import_featuregroup_redshift(my_jdbc_connector_name, sql_query, featuregroup_name, primary_key="id",
+    >>> featurestore.import_featuregroup_redshift(my_jdbc_connector_name, sql_query, featuregroup_name,
+    >>>                                  primary_keys=["id"],
     >>>                                  description="trx_summary_features without the column count_trx",
     >>>                                  featurestore=featurestore.project_featurestore(), featuregroup_version=1,
     >>>                                  jobs=[], descriptive_statistics=False,
@@ -1997,7 +1998,7 @@ def import_featuregroup_redshift(storage_connector, query, featuregroup, primary
         :storage_connector: the storage connector used to connect to the external storage
         :query: the queury extracting data from Redshift
         :featuregroup: name of the featuregroup to import the dataset into the featurestore
-        :primary_key: primary key of the featuregroup
+        :primary_keys: primary keys of the featuregroup
         :description: metadata description of the feature group to import
         :featurestore: name of the featurestore database to import the feature group into
         :featuregroup_version: version of the feature group
@@ -2030,7 +2031,7 @@ def import_featuregroup_redshift(storage_connector, query, featuregroup, primary
         spark_df = core._do_get_redshift_featuregroup(storage_connector, query,
                                             core._get_featurestore_metadata(featurestore, update_cache=False),
                                             featurestore=featurestore)
-        create_featuregroup(spark_df, featuregroup, primary_key=primary_key, description=description,
+        create_featuregroup(spark_df, featuregroup, primary_keys=primary_keys, description=description,
                             featurestore=featurestore, featuregroup_version=featuregroup_version, jobs=jobs,
                             descriptive_statistics=descriptive_statistics, feature_correlation=feature_correlation,
                             feature_histograms=feature_histograms, cluster_analysis=cluster_analysis,
@@ -2041,7 +2042,7 @@ def import_featuregroup_redshift(storage_connector, query, featuregroup, primary
         spark_df = core._do_get_redshift_featuregroup(storage_connector, query,
                                                       core._get_featurestore_metadata(featurestore, update_cache=True),
                                                       featurestore=featurestore)
-        create_featuregroup(spark_df, featuregroup, primary_key=primary_key, description=description,
+        create_featuregroup(spark_df, featuregroup, primary_keys=primary_keys, description=description,
                             featurestore=featurestore, featuregroup_version=featuregroup_version, jobs=jobs,
                             descriptive_statistics=descriptive_statistics, feature_correlation=feature_correlation,
                             feature_histograms=feature_histograms, cluster_analysis=cluster_analysis,
@@ -2052,7 +2053,7 @@ def import_featuregroup_redshift(storage_connector, query, featuregroup, primary
     fs_utils._log("Feature group imported successfully")
 
 
-def import_featuregroup_s3(storage_connector, path, featuregroup, primary_key=None, description="", featurestore=None,
+def import_featuregroup_s3(storage_connector, path, featuregroup, primary_keys=[], description="", featurestore=None,
                            featuregroup_version=1, jobs=[],
                            descriptive_statistics=True, feature_correlation=True,
                            feature_histograms=True, cluster_analysis=True, stat_columns=None, num_bins=20,
@@ -2068,7 +2069,7 @@ def import_featuregroup_s3(storage_connector, path, featuregroup, primary_key=No
     >>> featurestore.import_featuregroup_s3(my_s3_connector_name, s3_path, featuregroup_name,
     >>>                                  data_format=s3_bucket_data_format)
     >>> # You can also be explicitly specify featuregroup metadata and what statistics to compute:
-    >>> featurestore.import_featuregroup_s3(my_s3_connector_name, s3_path, featuregroup_name, primary_key="id",
+    >>> featurestore.import_featuregroup_s3(my_s3_connector_name, s3_path, featuregroup_name, primary_keys=["id"],
     >>>                                  description="trx_summary_features without the column count_trx",
     >>>                                  featurestore=featurestore.project_featurestore(),featuregroup_version=1,
     >>>                                  jobs=[], descriptive_statistics=False,
@@ -2080,7 +2081,7 @@ def import_featuregroup_s3(storage_connector, path, featuregroup, primary_key=No
         :storage_connector: the storage connector used to connect to the external storage
         :path: the path to read from the external storage
         :featuregroup: name of the featuregroup to import the dataset into the featurestore
-        :primary_key: primary key of the featuregroup
+        :primary_keys: primary keys of the featuregroup
         :description: metadata description of the feature group to import
         :featurestore: name of the featurestore database to import the feature group into
         :featuregroup_version: version of the feature group
@@ -2115,7 +2116,7 @@ def import_featuregroup_s3(storage_connector, path, featuregroup, primary_key=No
         spark_df = core._do_get_s3_featuregroup(storage_connector, path,
                                                 core._get_featurestore_metadata(featurestore, update_cache=False),
                                                 featurestore=featurestore, data_format=data_format)
-        create_featuregroup(spark_df, featuregroup, primary_key=primary_key, description=description,
+        create_featuregroup(spark_df, featuregroup, primary_keys=primary_keys, description=description,
                             featurestore=featurestore, featuregroup_version=featuregroup_version, jobs=jobs,
                             descriptive_statistics=descriptive_statistics, feature_correlation=feature_correlation,
                             feature_histograms=feature_histograms, cluster_analysis=cluster_analysis,
@@ -2126,7 +2127,7 @@ def import_featuregroup_s3(storage_connector, path, featuregroup, primary_key=No
         spark_df = core._do_get_s3_featuregroup(storage_connector, path,
                                                 core._get_featurestore_metadata(featurestore, update_cache=True),
                                                 featurestore=featurestore, data_format=data_format)
-        create_featuregroup(spark_df, featuregroup, primary_key=primary_key, description=description,
+        create_featuregroup(spark_df, featuregroup, primary_keys=primary_keys, description=description,
                             featurestore=featurestore, featuregroup_version=featuregroup_version, jobs=jobs,
                             descriptive_statistics=descriptive_statistics, feature_correlation=feature_correlation,
                             feature_histograms=feature_histograms, cluster_analysis=cluster_analysis,

--- a/hops/featurestore.py
+++ b/hops/featurestore.py
@@ -586,7 +586,7 @@ def create_on_demand_featuregroup(sql_query, featuregroup, jdbc_connector_name, 
     fs_utils._log("Feature group created successfully")
 
 
-def create_featuregroup(df, featuregroup, primary_keys=[], description="", featurestore=None,
+def create_featuregroup(df, featuregroup, primary_key=[], description="", featurestore=None,
                         featuregroup_version=1, jobs=[],
                         descriptive_statistics=True, feature_correlation=True,
                         feature_histograms=True, cluster_analysis=True, stat_columns=None, num_bins=20,
@@ -614,8 +614,8 @@ def create_featuregroup(df, featuregroup, primary_keys=[], description="", featu
     Args:
         :df: the dataframe to create the featuregroup for (used to infer the schema)
         :featuregroup: the name of the new featuregroup
-        :primary_keys: a list of primary keys of the new featuregroup, if not specified,
-                       the first column in the dataframe will be used as primary
+        :primary_key: a list of columns to be used as primary key of the new featuregroup, if not specified,
+                      the first column in the dataframe will be used as primary
         :description: a description of the featuregroup
         :featurestore: the featurestore of the featuregroup (defaults to the project's featurestore)
         :featuregroup_version: the version of the featuregroup (defaults to 1)
@@ -644,10 +644,16 @@ def create_featuregroup(df, featuregroup, primary_keys=[], description="", featu
     Raises:
         :CouldNotConvertDataframe: in case the provided dataframe could not be converted to a spark dataframe
     """
+    # Deprecation warning
+    if isinstance(primary_key, str):
+        print(
+            "DeprecationWarning: Primary key of type str is deprecated. With the introduction of composite primary keys"
+            " this method expects a list of strings to define the primary key.")
+        primary_key = [primary_key]
     # Try with the cache first
     try:
         core._do_create_featuregroup(df, core._get_featurestore_metadata(featurestore, update_cache=False),
-                                     featuregroup, primary_keys=primary_keys, description= description,
+                                     featuregroup, primary_key=primary_key, description= description,
                                      featurestore=featurestore, featuregroup_version=featuregroup_version,
                                      jobs=jobs, descriptive_statistics=descriptive_statistics,
                                      feature_correlation=feature_correlation, feature_histograms=feature_histograms,
@@ -657,7 +663,7 @@ def create_featuregroup(df, featuregroup, primary_keys=[], description="", featu
     # If it fails, update cache and retry
     except:
         core._do_create_featuregroup(df, core._get_featurestore_metadata(featurestore, update_cache=True),
-                                     featuregroup, primary_keys=primary_keys, description= description,
+                                     featuregroup, primary_key=primary_key, description= description,
                                      featurestore=featurestore, featuregroup_version=featuregroup_version,
                                      jobs=jobs, descriptive_statistics=descriptive_statistics,
                                      feature_correlation=feature_correlation, feature_histograms=feature_histograms,
@@ -1972,7 +1978,7 @@ def sync_hive_table_with_featurestore(featuregroup, description="", featurestore
     fs_utils._log("Hive Table: {} was successfully synchronized with Feature Store: {}".format(featuregroup,
                                                                                                featurestore))
 
-def import_featuregroup_redshift(storage_connector, query, featuregroup, primary_keys=[], description="",
+def import_featuregroup_redshift(storage_connector, query, featuregroup, primary_key=[], description="",
                                  featurestore=None, featuregroup_version=1, jobs=[], descriptive_statistics=True,
                                  feature_correlation=True, feature_histograms=True, cluster_analysis=True,
                                  stat_columns=None, num_bins=20, corr_method='pearson', num_clusters=5,
@@ -1987,7 +1993,7 @@ def import_featuregroup_redshift(storage_connector, query, featuregroup, primary
     >>> featurestore.import_featuregroup_redshift(my_jdbc_connector_name, sql_query, featuregroup_name)
     >>> # You can also be explicitly specify featuregroup metadata and what statistics to compute:
     >>> featurestore.import_featuregroup_redshift(my_jdbc_connector_name, sql_query, featuregroup_name,
-    >>>                                  primary_keys=["id"],
+    >>>                                  primary_key=["id"],
     >>>                                  description="trx_summary_features without the column count_trx",
     >>>                                  featurestore=featurestore.project_featurestore(), featuregroup_version=1,
     >>>                                  jobs=[], descriptive_statistics=False,
@@ -1998,7 +2004,8 @@ def import_featuregroup_redshift(storage_connector, query, featuregroup, primary
         :storage_connector: the storage connector used to connect to the external storage
         :query: the queury extracting data from Redshift
         :featuregroup: name of the featuregroup to import the dataset into the featurestore
-        :primary_keys: primary keys of the featuregroup
+        :primary_key: a list of columns to be used as primary key of the new featuregroup, if not specified,
+                      the first column in the dataframe will be used as primary key
         :description: metadata description of the feature group to import
         :featurestore: name of the featurestore database to import the feature group into
         :featuregroup_version: version of the feature group
@@ -2024,6 +2031,12 @@ def import_featuregroup_redshift(storage_connector, query, featuregroup, primary
     Returns:
         None
     """
+    # Deprecation warning
+    if isinstance(primary_key, str):
+        print(
+            "DeprecationWarning: Primary key of type str is deprecated. With the introduction of composite primary keys"
+            " this method expects a list of strings to define the primary key.")
+        primary_key = [primary_key]
     if featurestore is None:
         featurestore = project_featurestore()
 
@@ -2031,7 +2044,7 @@ def import_featuregroup_redshift(storage_connector, query, featuregroup, primary
         spark_df = core._do_get_redshift_featuregroup(storage_connector, query,
                                             core._get_featurestore_metadata(featurestore, update_cache=False),
                                             featurestore=featurestore)
-        create_featuregroup(spark_df, featuregroup, primary_keys=primary_keys, description=description,
+        create_featuregroup(spark_df, featuregroup, primary_key=primary_key, description=description,
                             featurestore=featurestore, featuregroup_version=featuregroup_version, jobs=jobs,
                             descriptive_statistics=descriptive_statistics, feature_correlation=feature_correlation,
                             feature_histograms=feature_histograms, cluster_analysis=cluster_analysis,
@@ -2042,7 +2055,7 @@ def import_featuregroup_redshift(storage_connector, query, featuregroup, primary
         spark_df = core._do_get_redshift_featuregroup(storage_connector, query,
                                                       core._get_featurestore_metadata(featurestore, update_cache=True),
                                                       featurestore=featurestore)
-        create_featuregroup(spark_df, featuregroup, primary_keys=primary_keys, description=description,
+        create_featuregroup(spark_df, featuregroup, primary_key=primary_key, description=description,
                             featurestore=featurestore, featuregroup_version=featuregroup_version, jobs=jobs,
                             descriptive_statistics=descriptive_statistics, feature_correlation=feature_correlation,
                             feature_histograms=feature_histograms, cluster_analysis=cluster_analysis,
@@ -2053,7 +2066,7 @@ def import_featuregroup_redshift(storage_connector, query, featuregroup, primary
     fs_utils._log("Feature group imported successfully")
 
 
-def import_featuregroup_s3(storage_connector, path, featuregroup, primary_keys=[], description="", featurestore=None,
+def import_featuregroup_s3(storage_connector, path, featuregroup, primary_key=[], description="", featurestore=None,
                            featuregroup_version=1, jobs=[],
                            descriptive_statistics=True, feature_correlation=True,
                            feature_histograms=True, cluster_analysis=True, stat_columns=None, num_bins=20,
@@ -2069,19 +2082,20 @@ def import_featuregroup_s3(storage_connector, path, featuregroup, primary_keys=[
     >>> featurestore.import_featuregroup_s3(my_s3_connector_name, s3_path, featuregroup_name,
     >>>                                  data_format=s3_bucket_data_format)
     >>> # You can also be explicitly specify featuregroup metadata and what statistics to compute:
-    >>> featurestore.import_featuregroup_s3(my_s3_connector_name, s3_path, featuregroup_name, primary_keys=["id"],
+    >>> featurestore.import_featuregroup_s3(my_s3_connector_name, s3_path, featuregroup_name, primary_key=["id"],
     >>>                                  description="trx_summary_features without the column count_trx",
     >>>                                  featurestore=featurestore.project_featurestore(),featuregroup_version=1,
     >>>                                  jobs=[], descriptive_statistics=False,
     >>>                                  feature_correlation=False, feature_histograms=False, cluster_analysis=False,
-    >>>                                  stat_columns=None, partition_by=[], data_format="parquet", online=False, 
+    >>>                                  stat_columns=None, partition_by=[], data_format="parquet", online=False,
     >>>                                  online_types=None, offline=True)
 
     Args:
         :storage_connector: the storage connector used to connect to the external storage
         :path: the path to read from the external storage
         :featuregroup: name of the featuregroup to import the dataset into the featurestore
-        :primary_keys: primary keys of the featuregroup
+        :primary_key: a list of columns to be used as primary key of the new featuregroup, if not specified,
+                      the first column in the dataframe will be used as primary key
         :description: metadata description of the feature group to import
         :featurestore: name of the featurestore database to import the feature group into
         :featuregroup_version: version of the feature group
@@ -2108,6 +2122,12 @@ def import_featuregroup_s3(storage_connector, path, featuregroup, primary_keys=[
     Returns:
         None
     """
+    # Deprecation warning
+    if isinstance(primary_key, str):
+        print(
+            "DeprecationWarning: Primary key of type str is deprecated. With the introduction of composite primary keys"
+            " this method expects a list of strings to define the primary key.")
+        primary_key = [primary_key]
     # update metadata cache
     if featurestore is None:
         featurestore = project_featurestore()
@@ -2116,7 +2136,7 @@ def import_featuregroup_s3(storage_connector, path, featuregroup, primary_keys=[
         spark_df = core._do_get_s3_featuregroup(storage_connector, path,
                                                 core._get_featurestore_metadata(featurestore, update_cache=False),
                                                 featurestore=featurestore, data_format=data_format)
-        create_featuregroup(spark_df, featuregroup, primary_keys=primary_keys, description=description,
+        create_featuregroup(spark_df, featuregroup, primary_key=primary_key, description=description,
                             featurestore=featurestore, featuregroup_version=featuregroup_version, jobs=jobs,
                             descriptive_statistics=descriptive_statistics, feature_correlation=feature_correlation,
                             feature_histograms=feature_histograms, cluster_analysis=cluster_analysis,
@@ -2127,7 +2147,7 @@ def import_featuregroup_s3(storage_connector, path, featuregroup, primary_keys=[
         spark_df = core._do_get_s3_featuregroup(storage_connector, path,
                                                 core._get_featurestore_metadata(featurestore, update_cache=True),
                                                 featurestore=featurestore, data_format=data_format)
-        create_featuregroup(spark_df, featuregroup, primary_keys=primary_keys, description=description,
+        create_featuregroup(spark_df, featuregroup, primary_key=primary_key, description=description,
                             featurestore=featurestore, featuregroup_version=featuregroup_version, jobs=jobs,
                             descriptive_statistics=descriptive_statistics, feature_correlation=feature_correlation,
                             feature_histograms=feature_histograms, cluster_analysis=cluster_analysis,

--- a/hops/featurestore_impl/core.py
+++ b/hops/featurestore_impl/core.py
@@ -119,14 +119,14 @@ def _get_featurestore_metadata(featurestore=None, update_cache=False):
     return metadata_cache
 
 
-def _convert_field_to_feature_json(field_dict, primary_key, partition_by, online=False, online_types = None):
+def _convert_field_to_feature_json(field_dict, primary_keys, partition_by, online=False, online_types = None):
     """
     Helper function that converts a field in a spark dataframe to a feature dict that is compatible with the
      featurestore API
 
     Args:
         :field_dict: the dict of spark field to convert
-        :primary_key: name of the primary key feature
+        :primary_keys: list of the names of the primary keys
         :partition_by: a list of columns to partition_by, defaults to the empty list
         :online: boolean flag whether the feature is to be used for online serving
         :online_types: dict with feature name --> online_type. If the field name is present in this dict,
@@ -147,7 +147,7 @@ def _convert_field_to_feature_json(field_dict, primary_key, partition_by, online
     else:
         f_type_online = None
     f_desc = ""
-    if f_name == primary_key:
+    if f_name in primary_keys:
         f_primary = True
     else:
         f_primary = False
@@ -179,13 +179,13 @@ def _convert_field_to_feature_json(field_dict, primary_key, partition_by, online
     }
 
 
-def _parse_spark_features_schema(spark_schema, primary_key, partition_by=[], online=False, online_types = None):
+def _parse_spark_features_schema(spark_schema, primary_keys=[], partition_by=[], online=False, online_types = None):
     """
     Helper function for parsing the schema of a spark dataframe into a list of feature-dicts
 
     Args:
         :spark_schema: the spark schema to parse
-        :primary_key: the column in the dataframe that should be the primary key
+        :primary_keys: list of the columns in the dataframe that should be the primary keys
         :partition_by: a list of columns to partition_by, defaults to the empty list
         :online: whether the features are to be used for online serving
         :online_types: a dict with feature_name --> online_type, if a feature is present in this dict,
@@ -197,7 +197,7 @@ def _parse_spark_features_schema(spark_schema, primary_key, partition_by=[], onl
     """
     raw_schema = json.loads(spark_schema.json())
     raw_fields = raw_schema[constants.SPARK_CONFIG.SPARK_SCHEMA_FIELDS]
-    parsed_features = list(map(lambda field: _convert_field_to_feature_json(field, primary_key, partition_by,
+    parsed_features = list(map(lambda field: _convert_field_to_feature_json(field, primary_keys, partition_by,
                                                                             online=online,
                                                                             online_types=online_types),
                                raw_fields))
@@ -936,7 +936,7 @@ def _do_create_training_dataset(df, training_dataset, description="", featuresto
             num_bins=num_bins,
             corr_method=corr_method,
             num_clusters=num_clusters)
-    features_schema = _parse_spark_features_schema(spark_df.schema, None)
+    features_schema = _parse_spark_features_schema(spark_df.schema)
     featurestore_id = _get_featurestore_id(featurestore)
     featurestore_metadata = _get_featurestore_metadata(featurestore, update_cache=False)
     hopsfs_connector_id = None
@@ -1771,7 +1771,7 @@ def _do_get_online_featurestore_connector(featurestore, featurestore_metadata):
         return JDBCStorageConnector(response_object)
 
 
-def _do_create_featuregroup(df, featurestore_metadata, featuregroup, primary_key=None, description="", featurestore=None,
+def _do_create_featuregroup(df, featurestore_metadata, featuregroup, primary_keys=[], description="", featurestore=None,
                             featuregroup_version=1, jobs=[],
                             descriptive_statistics=True, feature_correlation=True,
                             feature_histograms=True, cluster_analysis=True, stat_columns=None, num_bins=20,
@@ -1785,8 +1785,8 @@ def _do_create_featuregroup(df, featurestore_metadata, featuregroup, primary_key
     Args:
         :df: the dataframe to create the featuregroup for (used to infer the schema)
         :featuregroup: the name of the new featuregroup
-        :primary_key: the primary key of the new featuregroup, if not specified, the first column in the dataframe will
-                      be used as primary
+        :primary_keys: the primary keys of the new featuregroup, if not specified,
+                       the first column in the dataframe will be used as primary
         :description: a description of the featuregroup
         :featurestore: the featurestore of the featuregroup (defaults to the project's featurestore)
         :featuregroup_version: the version of the featuregroup (defaults to 1)
@@ -1829,13 +1829,13 @@ def _do_create_featuregroup(df, featurestore_metadata, featuregroup, primary_key
 
     fs_utils._validate_metadata(featuregroup, spark_df.dtypes, description)
 
-    if primary_key is None:
-        primary_key = fs_utils._get_default_primary_key(spark_df)
+    if len(primary_keys) == 0:
+        primary_keys = [fs_utils._get_default_primary_key(spark_df)]
     if util.get_job_name() is not None:
         jobs.append(util.get_job_name())
 
-    fs_utils._validate_primary_key(spark_df, primary_key)
-    features_schema = _parse_spark_features_schema(spark_df.schema, primary_key, partition_by, online=online,
+    fs_utils._validate_primary_keys(spark_df, primary_keys)
+    features_schema = _parse_spark_features_schema(spark_df.schema, primary_keys, partition_by, online=online,
                                                    online_types= online_types)
     feature_corr_data, featuregroup_desc_stats_data, features_histogram_data, cluster_analysis_data = \
         _compute_dataframe_stats(
@@ -1894,11 +1894,11 @@ def _do_enable_featuregroup_online(featuregroup_name, featuregroup_version, feat
 
     spark_df = _do_get_cached_featuregroup(featuregroup_name, featurestore_metadata, featurestore, featuregroup_version,
                                        constants.FEATURE_STORE.DATAFRAME_TYPE_SPARK,online=False)
-    primary_key = None
+    primary_keys = []
     for feature in fg.features:
         if feature.primary:
-            primary_key = feature.name
-    features_schema = _parse_spark_features_schema(spark_df.schema, primary_key, [], online=True,
+            primary_keys.append(feature.name)
+    features_schema = _parse_spark_features_schema(spark_df.schema, primary_keys, [], online=True,
                                                    online_types=online_types)
     featuregroup_id = fg.id
     featurestore_id = featurestore_metadata.featurestore.id

--- a/hops/featurestore_impl/util/fs_utils.py
+++ b/hops/featurestore_impl/util/fs_utils.py
@@ -279,13 +279,13 @@ def _get_default_primary_key(featuregroup_df):
     return featuregroup_df.dtypes[0][0]
 
 
-def _validate_primary_keys(featuregroup_df, primary_keys):
+def _validate_primary_key(featuregroup_df, primary_key):
     """
     Validates a user-supplied primary key
 
     Args:
         :featuregroup_df: the featuregroup_df that should contain the primary key
-        :primary_keys: the name of the primary keys
+        :primary_key: list of names of the columns of the primary key
 
     Returns:
         True if the validation succeeded, otherwise raises an error
@@ -294,11 +294,11 @@ def _validate_primary_keys(featuregroup_df, primary_keys):
         :InvalidPrimaryKey: when one or more of the primary keys does not exist in the dataframe
     """
     cols = list(map(lambda x: x[0], featuregroup_df.dtypes))
-    for pk in primary_keys:
+    for pk in primary_key:
         if pk not in cols:
             raise InvalidPrimaryKey(
                 "Invalid primary key: {}, the specified primary key does not exists among the available columns: {}" \
-                    .format(primary_keys, cols))
+                    .format(primary_key, cols))
     return True
 
 

--- a/hops/featurestore_impl/util/fs_utils.py
+++ b/hops/featurestore_impl/util/fs_utils.py
@@ -279,27 +279,28 @@ def _get_default_primary_key(featuregroup_df):
     return featuregroup_df.dtypes[0][0]
 
 
-def _validate_primary_key(featuregroup_df, primary_key):
+def _validate_primary_keys(featuregroup_df, primary_keys):
     """
     Validates a user-supplied primary key
 
     Args:
         :featuregroup_df: the featuregroup_df that should contain the primary key
-        :primary_key: the name of the primary key
+        :primary_keys: the name of the primary keys
 
     Returns:
         True if the validation succeeded, otherwise raises an error
 
     Raises:
-        :InvalidPrimaryKey: when the primary key does not exist in the dataframe
+        :InvalidPrimaryKey: when one or more of the primary keys does not exist in the dataframe
     """
     cols = list(map(lambda x: x[0], featuregroup_df.dtypes))
-    if primary_key in cols:
-        return True
-    else:
-        raise InvalidPrimaryKey(
-            "Invalid primary key: {}, the specified primary key does not exists among the available columns: {}" \
-                .format(primary_key,cols))
+    for pk in primary_keys:
+        if pk not in cols:
+            raise InvalidPrimaryKey(
+                "Invalid primary key: {}, the specified primary key does not exists among the available columns: {}" \
+                    .format(primary_keys, cols))
+    return True
+
 
 
 def _do_get_featuregroups(featurestore_metadata, online):

--- a/hops/tests/test_featurestore.py
+++ b/hops/tests/test_featurestore.py
@@ -788,9 +788,9 @@ class TestFeaturestoreSuite(object):
         teams_features_df = featurestore.get_featuregroup("teams_features")
         raw_schema = json.loads(teams_features_df.schema.json())
         raw_fields = raw_schema[constants.SPARK_CONFIG.SPARK_SCHEMA_FIELDS]
-        primary_key = "team_id"
+        primary_keys = ["team_id"]
         partition_by = []
-        parsed_feature = core._convert_field_to_feature_json(raw_fields[0], primary_key, partition_by)
+        parsed_feature = core._convert_field_to_feature_json(raw_fields[0], primary_keys, partition_by)
         assert constants.REST_CONFIG.JSON_FEATURE_NAME in parsed_feature
         assert constants.REST_CONFIG.JSON_FEATURE_TYPE in parsed_feature
         assert constants.REST_CONFIG.JSON_FEATURE_DESCRIPTION in parsed_feature
@@ -802,7 +802,7 @@ class TestFeaturestoreSuite(object):
         """ Test parse_spark_features_schema into hopsworks schema"""
         hdfs.project_name = mock.MagicMock(return_value="test_project")
         teams_features_df = featurestore.get_featuregroup("teams_features")
-        parsed_schema = core._parse_spark_features_schema(teams_features_df.schema, "team_id")
+        parsed_schema = core._parse_spark_features_schema(teams_features_df.schema, ["team_id"])
         assert len(parsed_schema) == len(teams_features_df.dtypes)
 
     def test_filter_spark_df_numeric(self):
@@ -933,15 +933,15 @@ class TestFeaturestoreSuite(object):
         teams_features_df = featurestore.get_featuregroup("teams_features")
         assert fs_utils._get_default_primary_key(teams_features_df) == "team_budget"
 
-    def test_validate_primary_key(self):
-        """ Test _validate_primary_key"""
+    def test_validate_primary_keys(self):
+        """ Test _validate_primary_keys"""
         hdfs.project_name = mock.MagicMock(return_value="test_project")
         teams_features_df = featurestore.get_featuregroup("teams_features")
-        assert fs_utils._validate_primary_key(teams_features_df, "team_budget")
-        assert fs_utils._validate_primary_key(teams_features_df, "team_id")
-        assert fs_utils._validate_primary_key(teams_features_df, "team_position")
+        assert fs_utils._validate_primary_keys(teams_features_df, ["team_budget"])
+        assert fs_utils._validate_primary_keys(teams_features_df, ["team_id"])
+        assert fs_utils._validate_primary_keys(teams_features_df, ["team_position"])
         with pytest.raises(InvalidPrimaryKey) as ex:
-            fs_utils._validate_primary_key(teams_features_df, "wrong_key")
+            fs_utils._validate_primary_keys(teams_features_df, ["wrong_key"])
             assert "Invalid primary key" in ex.value
 
     def test_delete_table_contents(self):
@@ -992,7 +992,7 @@ class TestFeaturestoreSuite(object):
         spark = self.spark_session()
         spark_df = spark.read.format("csv").option("header", "true").option("inferSchema", "true").load(
             "./hops/tests/test_resources/games_features.csv")
-        features_schema = core._parse_spark_features_schema(spark_df.schema, None)
+        features_schema = core._parse_spark_features_schema(spark_df.schema)
         response = mock.Mock()
         util.send_request = mock.MagicMock(return_value=response)
         response.status_code = 201
@@ -2847,5 +2847,14 @@ class TestFeaturestoreSuite(object):
         assert schema_dict[constants.SPARK_CONFIG.SPARK_SCHEMA_FIELDS][2][
                    constants.SPARK_CONFIG.SPARK_SCHEMA_FIELD_METADATA][
                    constants.FEATURE_STORE.TRAINING_DATASET_PROVENANCE_VERSION] == "1"
+
+
+    def test_create_featuregroup_composite_key(self, sample_metadata):
+        """ Test create_featuregroup with a composite primary key"""
+        hdfs.project_name = mock.MagicMock(return_value="test_project")
+        rest_rpc._create_featuregroup_rest = mock.MagicMock(return_value=None)
+        core._get_featurestore_metadata = mock.MagicMock(return_value=FeaturestoreMetadata(sample_metadata))
+        teams_features_df = featurestore.get_featuregroup("teams_features")
+        featurestore.create_featuregroup(teams_features_df, "teams_features", primary_keys=["team_budget", "team_id"])
 
 

--- a/hops/tests/test_featurestore.py
+++ b/hops/tests/test_featurestore.py
@@ -788,9 +788,9 @@ class TestFeaturestoreSuite(object):
         teams_features_df = featurestore.get_featuregroup("teams_features")
         raw_schema = json.loads(teams_features_df.schema.json())
         raw_fields = raw_schema[constants.SPARK_CONFIG.SPARK_SCHEMA_FIELDS]
-        primary_keys = ["team_id"]
+        primary_key = ["team_id"]
         partition_by = []
-        parsed_feature = core._convert_field_to_feature_json(raw_fields[0], primary_keys, partition_by)
+        parsed_feature = core._convert_field_to_feature_json(raw_fields[0], primary_key, partition_by)
         assert constants.REST_CONFIG.JSON_FEATURE_NAME in parsed_feature
         assert constants.REST_CONFIG.JSON_FEATURE_TYPE in parsed_feature
         assert constants.REST_CONFIG.JSON_FEATURE_DESCRIPTION in parsed_feature
@@ -933,15 +933,15 @@ class TestFeaturestoreSuite(object):
         teams_features_df = featurestore.get_featuregroup("teams_features")
         assert fs_utils._get_default_primary_key(teams_features_df) == "team_budget"
 
-    def test_validate_primary_keys(self):
-        """ Test _validate_primary_keys"""
+    def test_validate_primary_key(self):
+        """ Test _validate_primary_key"""
         hdfs.project_name = mock.MagicMock(return_value="test_project")
         teams_features_df = featurestore.get_featuregroup("teams_features")
-        assert fs_utils._validate_primary_keys(teams_features_df, ["team_budget"])
-        assert fs_utils._validate_primary_keys(teams_features_df, ["team_id"])
-        assert fs_utils._validate_primary_keys(teams_features_df, ["team_position"])
+        assert fs_utils._validate_primary_key(teams_features_df, ["team_budget"])
+        assert fs_utils._validate_primary_key(teams_features_df, ["team_id"])
+        assert fs_utils._validate_primary_key(teams_features_df, ["team_position"])
         with pytest.raises(InvalidPrimaryKey) as ex:
-            fs_utils._validate_primary_keys(teams_features_df, ["wrong_key"])
+            fs_utils._validate_primary_key(teams_features_df, ["wrong_key"])
             assert "Invalid primary key" in ex.value
 
     def test_delete_table_contents(self):
@@ -2855,6 +2855,6 @@ class TestFeaturestoreSuite(object):
         rest_rpc._create_featuregroup_rest = mock.MagicMock(return_value=None)
         core._get_featurestore_metadata = mock.MagicMock(return_value=FeaturestoreMetadata(sample_metadata))
         teams_features_df = featurestore.get_featuregroup("teams_features")
-        featurestore.create_featuregroup(teams_features_df, "teams_features", primary_keys=["team_budget", "team_id"])
+        featurestore.create_featuregroup(teams_features_df, "teams_features", primary_key=["team_budget", "team_id"])
 
 


### PR DESCRIPTION
This should be merged instead of #131 
We want to keep the argument name `primary_key` otherwise it will break the API for existing users.

https://logicalclocks.atlassian.net/browse/HOPSWORKS-1377