### PR TITLE
[HOPSWORKS-1680] Python jobs

### DIFF
--- a/hops/jobs.py
+++ b/hops/jobs.py
@@ -121,7 +121,7 @@ def stop_job(name):
     return response_object
 
 
-def get_executions(name, query=None):
+def get_executions(name, query=""):
     """
     Get a list of the currently running executions for this job.
     Returns:


### PR DESCRIPTION
Fix default value for REST API query in jobs