### PR TITLE
[HOPSWORKS-2004] get_latest_featuregroup_version not updating cache

### DIFF
--- a/hops/featurestore.py
+++ b/hops/featurestore.py
@@ -1154,14 +1154,10 @@ def get_latest_training_dataset_version(training_dataset, featurestore=None):
     """
     if featurestore is None:
         featurestore = project_featurestore()
-    try:
-        return fs_utils._do_get_latest_training_dataset_version(training_dataset,
-                                                                core._get_featurestore_metadata(featurestore,
-                                                                                                update_cache=False))
-    except:
-        return fs_utils._do_get_latest_training_dataset_version(training_dataset,
-                                                                core._get_featurestore_metadata(featurestore,
-                                                                                                update_cache=True))
+
+    return fs_utils._do_get_latest_training_dataset_version(training_dataset,
+                                                            core._get_featurestore_metadata(featurestore,
+                                                                                            update_cache=True))
 
 
 def get_latest_featuregroup_version(featuregroup, featurestore=None):
@@ -1182,14 +1178,9 @@ def get_latest_featuregroup_version(featuregroup, featurestore=None):
     if featurestore is None:
         featurestore = project_featurestore()
 
-    try:
-        return fs_utils._do_get_latest_featuregroup_version(featuregroup,
-                                                            core._get_featurestore_metadata(featurestore,
-                                                                                            update_cache=False))
-    except:
-        return fs_utils._do_get_latest_featuregroup_version(featuregroup,
-                                                            core._get_featurestore_metadata(featurestore,
-                                                                                            update_cache=False))
+    return fs_utils._do_get_latest_featuregroup_version(featuregroup,
+                                                        core._get_featurestore_metadata(featurestore,
+                                                                                        update_cache=True))
 
 
 def update_training_dataset_stats(training_dataset, training_dataset_version=1, featurestore=None,

--- a/hops/featurestore_impl/util/fs_utils.py
+++ b/hops/featurestore_impl/util/fs_utils.py
@@ -7,7 +7,8 @@ import json
 import numpy as np
 from hops.featurestore_impl.exceptions.exceptions import InferTFRecordSchemaError, \
     InvalidPrimaryKey, SparkToHiveSchemaConversionError, CouldNotConvertDataframe, \
-    SparkToMySQLSchemaConversionError, FeatureNotFound
+    SparkToMySQLSchemaConversionError, FeatureNotFound, FeaturegroupNotFound, \
+    TrainingDatasetNotFound
 import pandas as pd
 import math
 import re
@@ -55,7 +56,8 @@ def _do_get_latest_training_dataset_version(training_dataset_name, featurestore_
     if (len(versions) > 0):
         return max(versions)
     else:
-        return 0;
+        return TrainingDatasetNotFound("There was no version for featuregroup {} "
+                               "found".format(training_dataset_name))
 
 
 def _get_spark_array_size(spark_df, array_col_name):
@@ -257,7 +259,8 @@ def _do_get_latest_featuregroup_version(featuregroup_name, featurestore_metadata
     if (len(versions) > 0):
         return max(versions)
     else:
-        return 0
+        raise FeaturegroupNotFound("There was no version for featuregroup {} "
+                               "found".format(featuregroup_name))
 
 
 def _get_default_primary_key(featuregroup_df):

--- a/hops/featurestore_impl/util/fs_utils.py
+++ b/hops/featurestore_impl/util/fs_utils.py
@@ -56,7 +56,7 @@ def _do_get_latest_training_dataset_version(training_dataset_name, featurestore_
     if (len(versions) > 0):
         return max(versions)
     else:
-        return TrainingDatasetNotFound("There was no version for featuregroup {} "
+        return TrainingDatasetNotFound("There was no version for training dataset {} "
                                "found".format(training_dataset_name))
 
 

--- a/hops/featurestore_impl/util/fs_utils.py
+++ b/hops/featurestore_impl/util/fs_utils.py
@@ -56,7 +56,7 @@ def _do_get_latest_training_dataset_version(training_dataset_name, featurestore_
     if (len(versions) > 0):
         return max(versions)
     else:
-        return TrainingDatasetNotFound("There was no version for training dataset {} "
+        raise TrainingDatasetNotFound("There was no version for training dataset {} "
                                "found".format(training_dataset_name))
 
 


### PR DESCRIPTION
Fixes issue for feature groups and training datasets.
Always update the cache, otherwise it might end up returning a latest version which isn't actually the latest version.