### PR TITLE
[HOPSWORKS-2576] hops-util-py - elasticsearch module - always lower case index names

### DIFF
--- a/hops/elasticsearch.py
+++ b/hops/elasticsearch.py
@@ -21,7 +21,7 @@ def get_elasticsearch_index(index):
     Returns:
         A valid elasticsearch index name.
     """
-    return hdfs.project_name() + "_" + index
+    return (hdfs.project_name() + "_" + index).lower()
 
 
 def get_elasticsearch_config(index):


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-2576