### PR TITLE
Fix race condition during cleanup process.

### DIFF
--- a/hops/experiment_impl/util/experiment_utils.py
+++ b/hops/experiment_impl/util/experiment_utils.py
@@ -222,18 +222,19 @@ def _cleanup(tensorboard, gpu_thread):
     finally:
         tensorboard._reset_global()
 
+    # Stop the gpu monitoring thread
+    try:
+        gpu_thread.do_run = False
+        gpu_thread.join(timeout = 20)
+    except Exception as err:
+        print('Exception occurred while stopping GPU monitoring thread: {}'.format(err))
+        pass
+
     # Close and logging fd and flush
     try:
         _close_logger()
     except Exception as err:
         print('Exception occurred while closing logger: {}'.format(err))
-        pass
-
-    # Stop the gpu monitoring thread
-    try:
-        gpu_thread.do_run = False
-    except Exception as err:
-        print('Exception occurred while stopping GPU monitoring thread: {}'.format(err))
         pass
 
 def _store_local_tensorboard(local_tb_path, hdfs_exec_logdir):


### PR DESCRIPTION
When shutting down the experiment, we close the logger then terminate
the GPU monitoring thread. This can cause the monitoring thread to try
to log when the logger is already closed, throwing an exception to the
user.

In this PR we swap the other of the operations so that the logger
is closed after the GPU monitoring thread is stopped. As well as
we call .join() on the GPU monitoring thread to block until the method
_print_periodic_gpu_utilization has exited.

20 seconds timeout of the .join() method as the
_print_periodic_gpu_utilization method has a time.sleep(10) inside
the loop.